### PR TITLE
Get rid of module dependency for traits/interface maps

### DIFF
--- a/examples/array.jl
+++ b/examples/array.jl
@@ -1,0 +1,30 @@
+# Let's play with regular julia types
+
+# First, define traits.
+import Base: iterate
+@trait Iterable prefix Is,Not
+@implement IsIterable by iterate()::Any
+@implement IsIterable by iterate(state::Any)::Any
+
+import Base: length
+@trait Length prefix Has,No
+@implement HasLength by length()::Int
+
+const Int1D = Array{Int,1}
+@assign Int1D with Iterable, Length
+
+traits(Int1D)
+#=
+julia> traits(Int1D)
+Set{DataType} with 2 elements:
+  HasLength
+  IsIterable
+=#
+
+# Do we have a good implementation?
+@check Int1D
+#=
+julia> @check Int1D
+BinaryTraits.InterfaceReview(Array{Int64,1}) has fully implemented all interface contracts
+=#
+

--- a/examples/counter.jl
+++ b/examples/counter.jl
@@ -17,18 +17,36 @@ end
 
 # In my module initialization function, I can validate my implementation.
 @check Counter
+#=
+julia> @check Counter
+BinaryTraits.InterfaceReview(Counter) is missing the following implementations:
+1. IsIterable ⇢ iterate(::<Type>)::Any
+2. IsIterable ⇢ iterate(::<Type>, ::Any)::Any
+=#
 
 # now define iterate function
 Base.iterate(c::Counter, state = 0) = c.n > state ? (state+1,state+1) : nothing
 
 # now fully implemented
 @check Counter
+#=
+julia> @check Counter
+BinaryTraits.InterfaceReview(Counter) has fully implemented all interface contracts
+=#
 
 # ok to use
 sum(x for x in Counter(3))
+#=
+julia> sum(x for x in Counter(3))
+6
+=#
 
 # But array comprehension is broken without a length
 [x for x in Counter(3)]
+#=
+julia> [x for x in Counter(3)]
+ERROR: MethodError: no method matching length(::Counter)
+=#
 
 # Create new Length trait
 import Base: length
@@ -42,6 +60,31 @@ import Base: length
 Base.length(c::Counter) = c.n
 @check Counter  # all good
 
-[x for x in Counter(3)]
+[x for x in Counter(3)]  # Hooray!
+#=
+julia> [x for x in Counter(3)]  # Hooray!
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
+=#
 
+# What have we done so far?
+traits(Counter)
+#=
+julia> traits(Counter)
+Set{DataType} with 2 elements:
+  HasLength
+  IsIterable
+=#
+
+@trait Comprehensible prefix Is,Not with Iterable,Length
+@assign Counter with Comprehensible
+
+# Is a Counter comprehensible?  It better be!
+comprehensibletrait(Counter(2))
+#=
+julia> comprehensibletrait(Counter(2))
+IsComprehensible()
+=#
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -218,7 +218,7 @@ macro implement(can_type, by, sig)
     # generate code
     expr = quote
         function $func_name end
-        BinaryTraits.register($__module__, $can_type, $func_name,
+        BinaryTraits.register($can_type, $func_name,
             ($(func_arg_types...),), $return_type)
     end
     display_expanded_code(expr)

--- a/src/trait.jl
+++ b/src/trait.jl
@@ -64,8 +64,8 @@ macro trait(name::Symbol, args...)
         abstract type $trait_type <: $category end
         struct $can_type <: $trait_type end
         struct $cannot_type <: $trait_type end
-        BinaryTraits.istrait(::Type{$trait_type}) = true
         $(default_trait_function)(x::Any) = $default_expr
+        BinaryTraits.istrait(::Type{$trait_type}) = true
         nothing
     end
     display_expanded_code(expr)
@@ -112,7 +112,7 @@ macro assign(T::Symbol, with::Symbol, traits::Union{Expr,Symbol})
 
         # e.g. BinaryTraits.assign(MyModule, Duck, CanFly)
         push!(expressions, :(
-            BinaryTraits.assign($__module__, $T, $can_type)
+            BinaryTraits.assign($T, $can_type)
         ))
     end
     expr = quote


### PR DESCRIPTION
It seems to be design flaw to maintain trait types and interface contracts by module.  That's because a type may be defined in one module but then imported into another module.  So it becomes confusing where it came from.  For example, if I am going to define a trait that is used for Base types, then should I use my module or Base for lookup?

Since we can always find out the module of a data type using `parentmodule` function, I want to simplify the design and get rid of the 2-layer dict.  Hence this PR.