### PR TITLE
Required contracts introspection

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,8 +57,10 @@ macro as shown below:
 
 ```julia
 julia> @check Duck
-InterfaceReview(Duck) missing the following implementations:
-1. CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Nothing
+┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Duck, ::Float64, ::Float64)::Nothing
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:169
+❌ Duck is missing these implementations:
+1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Nothing
 ```
 
 Now, let's implement the method and check again:
@@ -67,24 +69,27 @@ Now, let's implement the method and check again:
 julia> fly(duck::Duck, direction::Float64, altitude::Float64) = "Having fun!"
 
 julia> @check Duck
-InterfaceReview(Duck) has fully implemented these contracts:
-1. CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Nothing
+✅ Duck has implemented:
+1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Nothing
 ```
 
 ## Applying holy traits
 
-If we would just implement interface contracts directly then it can be too specific
-for what it is worth.  If we have 100 flying animals, I shouldn't need to define
+If we would just implement interface contracts directly on concrete types then it can
+be too specific for what it is worth.  If we have 100 flying animals, I shouldn't need to define
 100 interface methods for the 100 concrete types.
 
 That's how Holy Trais pattern kicks in.  Rather than implementing the `fly` method
-as shown in the previous section, we could have implemented the following two
+for `Duck` as shown in the previous section, we could have implemented the following
 functions instead:
 
 ```julia
-fly(::CanFly, x, direction::Float64, altitude::Float64) = "Having fun!"
 fly(x, direction::Float64, altitude::Float64) = fly(flytrait(x), x, direction, altitude)
+fly(::CanFly, x, direction::Float64, altitude::Float64) = "Having fun!"
+fly(::CannotFly, x, direction::Float64, altitude::Float64) = "Too bad..."
 ```
 
-By definition, the `CanFly` trait should not be animal specific.  Hence generalizing
-the implementation with the `CanFly` argument makes perfect sense.
+The first function determines whether the object exhibits `CanFly` or `CannotFly` trait
+and dispatch to the proper function. We did not specify the type of the `x` argument
+but in reality if we are dealing with the animal kingdom only then we can define an
+abstract type `Animal` and apply holy traits to all `Animal` objects only.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,6 +13,7 @@
 ```@docs
 traits
 istrait
+required_contracts
 ```
 
 ## Types

--- a/examples/array.jl
+++ b/examples/array.jl
@@ -1,4 +1,5 @@
 # Let's play with regular julia types
+using Revise, BinaryTraits
 
 # First, define traits.
 import Base: iterate
@@ -28,3 +29,10 @@ julia> @check Int1D
 BinaryTraits.InterfaceReview(Array{Int64,1}) has fully implemented all interface contracts
 =#
 
+# Which contracts are required?
+#=
+julia> BinaryTraits.required_contracts(Int1D)
+2-element Array{Pair{DataType,Set{BinaryTraits.Contract}},1}:
+   LengthTrait => Set([HasLength ⇢ length(::<Type>)::Int64])
+ IterableTrait => Set([IsIterable ⇢ iterate(::<Type>, ::Any)::Any, IsIterable ⇢ iterate(::<Type>)::Any])
+=#

--- a/src/BinaryTraits.jl
+++ b/src/BinaryTraits.jl
@@ -4,7 +4,7 @@ using MacroTools
 
 export @trait, @assign
 export @implement, @check
-export traits, istrait
+export traits, istrait, required_contracts
 
 include("misc.jl")
 include("utils.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -132,19 +132,16 @@ end
 function Base.show(io::IO, ir::InterfaceReview)
     T = InterfaceReview
     if length(ir.implemented) == length(ir.misses) == 0
-        print(io, "$T($(ir.type)) does not need to implement any interface contracts")
-        return nothing
+        print(io, "✅ $(ir.type) has no interface contract requirements.")
     end
-    if ir.result
-        print(io, "$T($(ir.type)) has fully implemented all interface contracts")
-        if VERBOSE[]
-            println(io, ":")
-            for (i, c) in enumerate(ir.implemented)
-                println(io, "$(i). $c")
-            end
+    if length(ir.implemented) > 0
+        println(io, "✅ $(ir.type) has implemented:")
+        for (i, c) in enumerate(ir.implemented)
+            println(io, "$(i). $c")
         end
-    else
-        println(io, "$T($(ir.type)) is missing the following implementations:")
+    end
+    if length(ir.misses) > 0
+        println(io, "❌ $(ir.type) is missing these implementations:")
         for (i, c) in enumerate(ir.misses)
             println(io, "$(i). $c")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,13 +166,13 @@ module Interfaces
             contains(s) = x -> occursin(s, x)
 
             show(buf, flamingo_check)
-            @test buf |> take! |> String |> contains("does not need to implement any interface contracts")
+            @test buf |> take! |> String |> contains("has no interface contract requirements")
 
             show(buf, bird_check)
-            @test buf |> take! |> String |> contains("fully implemented")
+            @test buf |> take! |> String |> contains("has implemented")
 
             show(buf, duck_check)
-            @test buf |> take! |> String |> contains("missing")
+            @test buf |> take! |> String |> contains("is missing")
 
             # Bird is assigned with 1 FlyTrait and that requires 3 contracts
             @test required_contracts(Bird) |> length == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,8 @@ module SingleTrait
 
     function test()
         @testset "Single Trait" begin
-            @test istrait(FlyTrait)
+            @test istrait(FlyTrait) == true
+            @test istrait(Int) == false
             @test supertype(FlyTrait) === Any
             @test supertype(CanFly) <: FlyTrait
             @test supertype(CannotFly) <: FlyTrait

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,6 +173,10 @@ module Interfaces
 
             show(buf, duck_check)
             @test buf |> take! |> String |> contains("missing")
+
+            # Bird is assigned with 1 FlyTrait and that requires 3 contracts
+            @test required_contracts(Bird) |> length == 1
+            @test required_contracts(Bird)[1] |> last |> length == 3
         end
     end
 end


### PR DESCRIPTION
This PR implements a new `required_contracts` function which returns an array of pairs.  Each pair contains the trait type e.g. `FlyTrait` and a `Set{Contract}`.