### PR TITLE
Implemented composite trait lookthrough

### DIFF
--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -182,11 +182,15 @@ check(Bird)
 ```
 
 The `check` function returns an `InterfaceReview` object, which gives you the
-validation result.  Continuing with the same example above:
+validation result.  The warnings are generated so that it comes up in the log file.
+The following text is the display for the `InterfaceReview` object.  It is designed
+to clearly show you what has been implemented and what's not.
 
-The warnings are generated so that it comes up in the log file.   The following text
-is the display for the `InterfaceReview` object.  It is designed to clearly show you
-what has been implemented and what's not.
+!!! note
+    When you define composite traits, all contracts from the underlying traits must be
+    implemented as well.  If you have a `FlySwim` trait, then all contracts specified
+    for `CanFly` and `CanSwim` are required even though you have not added any new
+    contracts for `CanFlySwim`.
 
 !!! note
     One way to utilize the `check` function is to put that in your module's `__init__` function

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,6 +11,9 @@ Every motivation starts with an example.  In this page, we cover the following t
 Suppose that we are modeling the ability of animals.  So we can define traits as follows:
 
 ```@example ex
+using BinaryTraits
+
+# define traits
 abstract type Ability end
 @trait Swim as Ability
 @trait Fly as Ability

--- a/examples/array.jl
+++ b/examples/array.jl
@@ -36,7 +36,8 @@ julia> check(Int1D)
 required_contracts(Int1D)
 #=
 julia> required_contracts(Int1D)
-2-element Array{Pair{DataType,Set{BinaryTraits.Contract}},1}:
-   LengthTrait => Set([LengthTrait: HasLength ⇢ length(::<Type>)::Int64])
- IterableTrait => Set([IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any, IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any])
+Set{BinaryTraits.Contract} with 3 elements:
+  IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+  LengthTrait: HasLength ⇢ length(::<Type>)::Int64
+  IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
 =#

--- a/examples/counter.jl
+++ b/examples/counter.jl
@@ -111,3 +111,12 @@ julia> comprehensibletrait(Counter(2))
 IsComprehensible()
 =#
 
+required_contracts(Counter)
+#=
+julia> required_contracts(Counter)
+Set{BinaryTraits.Contract} with 3 elements:
+  IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+  LengthTrait: HasLength ⇢ length(::<Type>)::Int64
+  IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
+=#
+

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,3 +1,12 @@
+"""
+    Assignable
+
+`Assignable` represents any data type that can be associated with traits.
+It essentially covers all data types including parametric types e.g. `AbstractArray`
+"""
+const Assignable = Union{UnionAll, DataType}
+
+
 struct SyntaxError <: Exception
     msg
 end


### PR DESCRIPTION
Composite traits are special because they require all underlying traits.  We need a "lookthrough" facility such that the any underlying interface contracts are considered when checking for the interface validity of a data type.

The design is to add a new Dict `composite_traits` that maintains the can-type of the composite trait to the can-types of the underlying traits.  Once we have that, we can recursively look up the contracts from the underlying's can-types.

This PR includes:
- Updates to `contracts` and `required_contracts` functions
- Updates to test suite for testing composite traits
- Documentation updates