### PR TITLE
Relax contract function argument to any tuple

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -54,10 +54,10 @@ the Can-type of a trait. The function `func` must accepts `args` and returns `re
 - `args`: arguments of the function `func`
 - `ret`: return type of the function `func`
 """
-struct Contract{T <: DataType, F <: Function, N}
+struct Contract{T <: DataType, F <: Function}
     can_type::T
     func::F
-    args::NTuple{N, DataType}
+    args::Tuple
     ret::Union{DataType,Nothing}
 end
 
@@ -85,8 +85,8 @@ a value of type `ret`.
 """
 function register(can_type::DataType,
                   func::Function,
-                  args::NTuple{N,DataType},
-                  ret::Union{DataType,Nothing} = nothing) where N
+                  args::Tuple,
+                  ret::Union{DataType,Nothing} = nothing)
     contracts = get!(interface_map, can_type, Set{Contract}())
     push!(contracts, Contract(can_type, func, args, ret))
     return nothing


### PR DESCRIPTION
When battle-testing with `AbstractArray` interface, it becomes clear that some interface contracts needs to be specified with duck typing e.g. `setindex!(x, v, i::Int)` where the type of `v` is not specified. 

The interface check is based upon a subtype check.  For example, if the interface specifies that a function accepts `Any`, then any implementation that only supports a subtype would not be compliant because it does not cover all other types that falls under `Any`.  This is related to the contra-variances.  So, when the interface calls for duck typing, it actually need to refer to the `Base.Bottom` data type, which is the bottom-most data type of the type hierarchy.  Hence, any function definition taking any type will make it compliant with the contract.

For that reason, the `Contract.args` field must accept a type that includes any data type + Bottom.  But `Bottom <: DataType` is not true.  To keep it simple, I have relaxed the typing from `NTuple{N,DataType}` to just any `Tuple`.
