### PR TITLE
keyword args and other additions interface definitions

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -169,7 +169,11 @@ function check(T::Assignable)
     for can_type in traits(T)
         for c in contracts(can_type)
             tuple_type = Tuple{T, c.args...}
-            method_exists = hasmethod(c.func, tuple_type, c.kwargs)
+            method_exists = if VERSION >= v"1.2"
+                hasmethod(c.func, tuple_type, c.kwargs)
+            else
+                hasmethod(c.func, tuple_type)
+            end
             sig = replace("$c", TYPE_PLACEHOLDER => "::$T")
             if method_exists
                 push!(implemented_contracts, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,9 +178,11 @@ module Interfaces
     @assign Penguin with Dive
     @implement CanDive by dive1(::Integer)           # missing argument name
     @implement CanDive by dive2(::Vector{<:Integer}) # parameterized type
+    if VERSION >= v"1.2"
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
+I   end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom
@@ -224,7 +226,7 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == 7
+            @test penguin_check.implemented |> length == VERSION >= v"1.2" ? 7 : 4
             @test penguin_check.misses |> length == 1
 
             # test `show` function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ module Interfaces
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-I   end
+   end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ module Interfaces
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-   end
+    end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom
@@ -226,7 +226,7 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == VERSION >= v"1.2" ? 7 : 4
+            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
             @test penguin_check.misses |> length == 1
 
             # test `show` function


### PR DESCRIPTION
Fixes #25 , fixes #26, fixes #27 

Changes in `interface.jl`.

The argument list of the specified function in extended in 3 ways:

25: an argument name without argument type obtains default type `Base.Bottom`
26: the argument type can be an arbitrary expression, for example with type parameters
27: keyword arguments are supported - note: the keyword argument types are ignored
