### PR TITLE
replace `hasmethod` by correct implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /dev/
 .vscode/**
 docs/build
+*.cov
+*.mem

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -307,6 +307,7 @@ supported.
 This is an improvement over `Base.hasmethod` as it treats the `Base.Bottom` case correctly.
 """
 function has_method(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}=())
+    (VERSION >= v"1.2" ? hasmethod(f, t) : hasmethod(f, t, kwnames)) && return true
     t = Base.to_tuple_type(t)
     t = Base.signature_type(f, t)
     for m in methods(f)
@@ -325,7 +326,8 @@ function check_method(@nospecialize(m::Method), @nospecialize(sig::Type{T}), kwn
     end
     isempty(kwnames) || return true
     VERSION >= v"1.2" || return false
-    kws = Base.kwarg_decl(m)
+    par = VERSION >= v"1.4" ? nothing : Core.kwftype(m.sig.parameters[1])
+    kws = Base.kwarg_decl(m, par)
     for kw in kws
         endswith(String(kw), "...") && return true
     end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -307,13 +307,17 @@ supported.
 This is an improvement over `Base.hasmethod` as it treats the `Base.Bottom` case correctly.
 """
 function has_method(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}=())
-    (VERSION >= v"1.2" ? hasmethod(f, t, kwnames) : hasmethod(f, t)) && return true
+    _hasmethod(f, t, kwnames) && return true
     t = Base.to_tuple_type(t)
     t = Base.signature_type(f, t)
     for m in methods(f)
         check_method(m, t, kwnames) && return true
     end
     false
+end
+
+function _hasmethod(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}=())
+    VERSION >= v"1.2" && !isempty(kwnames) ? hasmethod(f, t, kwnames) : hasmethod(f, t)
 end
 
 function check_method(@nospecialize(m::Method), @nospecialize(sig::Type{T}), kwnames::Tuple{Vararg{Symbol}}=tuple()) where T<:Tuple
@@ -324,7 +328,7 @@ function check_method(@nospecialize(m::Method), @nospecialize(sig::Type{T}), kwn
     for i = 1:n
         ssig[i] <: msig[i] || return false
     end
-    isempty(kwnames) || return true
+    isempty(kwnames) && return true
     VERSION >= v"1.2" || return false
     par = VERSION >= v"1.4" ? nothing : Core.kwftype(m.sig.parameters[1])
     kws = Base.kwarg_decl(m, par)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -321,7 +321,7 @@ supported.
 This is an improvement over `Base.hasmethod` as it treats the `Base.Bottom` case correctly.
 """
 function has_method(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}=())
-    _hasmethod(f, t, kwnames) && return true
+    _hasmethod(f, t, kwnames) && return true # assume hasmethod has no false positives
     t = Base.to_tuple_type(t)
     t = Base.signature_type(f, t)
     for m in methods(f)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -307,7 +307,7 @@ supported.
 This is an improvement over `Base.hasmethod` as it treats the `Base.Bottom` case correctly.
 """
 function has_method(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}=())
-    (VERSION >= v"1.2" ? hasmethod(f, t) : hasmethod(f, t, kwnames)) && return true
+    (VERSION >= v"1.2" ? hasmethod(f, t, kwnames) : hasmethod(f, t)) && return true
     t = Base.to_tuple_type(t)
     t = Base.signature_type(f, t)
     for m in methods(f)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -169,7 +169,11 @@ function check(T::Assignable)
     for can_type in traits(T)
         for c in contracts(can_type)
             tuple_type = Tuple{T, c.args...}
-            method_exists = hasmethod(c.func, tuple_type, c.kwargs)
+            method_exists = if VERSION >= v"1.2"
+                hasmethod(c.func, tuple_type, c.kwargs)
+            else
+                hasmethod(c.func, tuple_type)
+            end
             sig = replace("$c", TYPE_PLACEHOLDER => "::$T")
             if method_exists
                 push!(implemented_contracts, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,9 +178,11 @@ module Interfaces
     @assign Penguin with Dive
     @implement CanDive by dive1(::Integer)           # missing argument name
     @implement CanDive by dive2(::Vector{<:Integer}) # parameterized type
+    if VERSION >= v"1.2"
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
+I   end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom
@@ -224,7 +226,7 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == 7
+            @test penguin_check.implemented |> length == VERSION >= v"1.2" ? 7 : 4
             @test penguin_check.misses |> length == 1
 
             # test `show` function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ module Interfaces
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-I   end
+   end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,8 @@ end
 module Interfaces
     using BinaryTraits, Test
 
+    const SUPPORT_KWARGS = VERSION >= v"1.2"
+
     # Fly trait requires multiple contracts with variety of func signatures
     @trait Fly
     @implement CanFly by liftoff()
@@ -176,13 +178,13 @@ module Interfaces
     struct Penguin end
     @trait Dive
     @assign Penguin with Dive
-    @implement CanDive by dive1(::Integer)           # missing argument name
+    @implement CanDive by dive1(::Integer)           # no argument name
     @implement CanDive by dive2(::Vector{<:Integer}) # parameterized type
-    if VERSION >= v"1.2"
-    @implement CanDive by dive31(x::Real;)            # keyword arguments
-    @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
-    @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-    @implement CanDive by dive34(x;kw1)
+    if SUPPORT_KWARGS
+        @implement CanDive by dive31(x::Real;)            # keyword arguments
+        @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
+        @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
+        @implement CanDive by dive34(x;kw1)
     end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(x)
@@ -228,8 +230,8 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
-            @test penguin_check.misses |> length == (VERSION >= v"1.2" ? 2 : 1)
+            @test penguin_check.implemented |> length == (SUPPORT_KWARGS ? 7 : 4)
+            @test penguin_check.misses |> length == (SUPPORT_KWARGS ? 2 : 1)
 
             # test `show` function
             buf = IOBuffer()
@@ -251,7 +253,7 @@ module Interfaces
             @test required_contracts(Crane) |> length == 4
 
             # Penguin
-            if VERSION >= v"1.2"
+            if SUPPORT_KWARGS
                 show(buf, penguin_check.misses)
                 @test buf |> take! |> String |> contains("dive34")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ module Interfaces
     @implement CanDive by dive31(x::Real;)            # keyword arguments
     @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
     @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-   end
+    end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(::Base.Bottom)
     @implement CanDive by dive6(x)              # default type is Base.Bottom
@@ -226,7 +226,7 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == VERSION >= v"1.2" ? 7 : 4
+            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
             @test penguin_check.misses |> length == 1
 
             # test `show` function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,9 +225,9 @@ module Interfaces
             @test crane_check.misses |> length == 1
 
             penguin_check = check(Penguin)
-            @test penguin_check.result == false
-            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
-            @test penguin_check.misses |> length == 1
+            @test penguin_check.result == true
+            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 8 : 5)
+            @test penguin_check.misses |> length == 0
 
             # test `show` function
             buf = IOBuffer()
@@ -248,9 +248,6 @@ module Interfaces
             # Crane requires 4 contracts because it has both Fly and Pretty traits
             @test required_contracts(Crane) |> length == 4
 
-            # Penguin is unexpectedly missing dive5
-            show(buf, penguin_check.misses)
-            @test buf |> take! |> String |> contains("dive5")
         end
     end
 end


### PR DESCRIPTION
Fixes #25.

This PR includes the previous #28.
The `Base.hasmethod` has a known bug (in highly optimized C-code, see JuliaLang/julia#30808), which is not being removed for a year. It does not work correctly, if the one of the method argument types is `Base.Bottom`.
As we don't need the high performance, a solution was implemented in `Julia`.