### PR TITLE
propagate interface contracts to subtypes

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -25,9 +25,14 @@ Returns a set of Can-types that the data type `T` exhibits.
 See also [`@assign`](@ref).
 """
 function traits(T::Assignable)
-    return get!(traits_map, T, Set{DataType}())
+    base = get!(traits_map, T) do; Set{DataType}() end
+    for (Tmap, s) in pairs(traits_map)
+        if T !== Tmap && T <: Tmap
+            union!(base, s)
+        end
+    end
+    base
 end
-
 
 """
     assign(T::Assignable, can_type::DataType)
@@ -35,7 +40,7 @@ end
 Assign data type `T` with the specified Can-type of a trait.
 """
 function assign(T::Assignable, can_type::DataType)
-    traits_set = get!(traits_map, T, Set{DataType}())
+    traits_set = get!(traits_map, T) do; Set{DataType}() end
     push!(traits_set, can_type)
     return nothing
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -31,7 +31,7 @@ function traits(T::Assignable)
             union!(base, s)
         end
     end
-    base
+    return base
 end
 
 """
@@ -99,7 +99,7 @@ function register(can_type::DataType,
                   args::Tuple,
                   kwargs::NTuple{N,Symbol},
                   ret::Union{DataType,Nothing} = nothing) where N
-    contracts = get!(interface_map, can_type, Set{Contract}())
+    contracts = get!(interface_map, can_type) do; Set{Contract}() end
     push!(contracts, Contract(can_type, func, args, kwargs, ret))
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,6 +198,13 @@ module Interfaces
     dive5(::Penguin, ::Int) = 5                 # Int >: Bottom
     dive6(::Penguin, ::Int) = 6                 # not Int >: Number
 
+    abstract type Animal end
+    struct Rabbit <: Animal end
+    @trait Eat
+    @assign Animal with Eat
+    @implement CanEat by eat()
+    eat(::Animal) = 1
+
     function test()
         @testset "Interface validation" begin
 
@@ -230,6 +237,9 @@ module Interfaces
             @test penguin_check.result == false
             @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
             @test penguin_check.misses |> length == (VERSION >= v"1.2" ? 2 : 1)
+
+            rabbit_check = check(Rabbit)
+            @test rabbit_check.result == true
 
             # test `show` function
             buf = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,8 @@ end
 module Interfaces
     using BinaryTraits, Test
 
+    const SUPPORT_KWARGS = VERSION >= v"1.2"
+
     # Fly trait requires multiple contracts with variety of func signatures
     @trait Fly
     @implement CanFly by liftoff()
@@ -176,13 +178,13 @@ module Interfaces
     struct Penguin end
     @trait Dive
     @assign Penguin with Dive
-    @implement CanDive by dive1(::Integer)           # missing argument name
+    @implement CanDive by dive1(::Integer)           # no argument name
     @implement CanDive by dive2(::Vector{<:Integer}) # parameterized type
-    if VERSION >= v"1.2"
-    @implement CanDive by dive31(x::Real;)            # keyword arguments
-    @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
-    @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
-    @implement CanDive by dive34(x;kw1)
+    if SUPPORT_KWARGS
+        @implement CanDive by dive31(x::Real;)            # keyword arguments
+        @implement CanDive by dive32(x::Real; kw::Real)   # keyword arguments
+        @implement CanDive by dive33(x::Real; kw1::Real, kw2) # keyword arguments
+        @implement CanDive by dive34(x;kw1)
     end
     @implement CanDive by dive4(::Base.Bottom)
     @implement CanDive by dive5(x)
@@ -198,6 +200,7 @@ module Interfaces
     dive5(::Penguin, ::Int) = 5                 # Int >: Bottom
     dive6(::Penguin, ::Int) = 6                 # not Int >: Number
 
+    # Issue #30 - propagate interfaces according to type inheritance
     abstract type Animal end
     struct Rabbit <: Animal end
     @trait Eat
@@ -235,8 +238,8 @@ module Interfaces
 
             penguin_check = check(Penguin)
             @test penguin_check.result == false
-            @test penguin_check.implemented |> length == (VERSION >= v"1.2" ? 7 : 4)
-            @test penguin_check.misses |> length == (VERSION >= v"1.2" ? 2 : 1)
+            @test penguin_check.implemented |> length == (SUPPORT_KWARGS ? 7 : 4)
+            @test penguin_check.misses |> length == (SUPPORT_KWARGS ? 2 : 1)
 
             rabbit_check = check(Rabbit)
             @test rabbit_check.result == true
@@ -261,7 +264,7 @@ module Interfaces
             @test required_contracts(Crane) |> length == 4
 
             # Penguin
-            if VERSION >= v"1.2"
+            if SUPPORT_KWARGS
                 show(buf, penguin_check.misses)
                 @test buf |> take! |> String |> contains("dive34")
             end


### PR DESCRIPTION
Fixes #30.

If a supertype or unionall `A` has assigned a trait, then all subtypes or specializations `B <: A` automatically complies to the trait, if `A` does, because `foo(::A)` is called by `foo(B())`. 

To determine the `traits(T::Assignable)` collect all keys `key` of `traits_map` which have `k <: T` and build the union of all the sets of traits associated with those keys.