### PR TITLE
Breaking change and major refactoring (@check macro)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,10 +57,10 @@ implement a `fly` method.  We can define that interface as follows:
 ```
 
 Then, to make sure that our implementation is correct, we can use the `check`
-function as shown below:
+macro as shown below:
 
 ```julia
-julia> check(Duck)
+julia> @check(Duck)
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Duck, ::Float64, ::Float64)::Nothing
 └ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:170
 ❌ Duck is missing these implementations:
@@ -72,7 +72,7 @@ Now, let's implement the method and check again:
 ```julia
 julia> fly(duck::Duck, direction::Float64, altitude::Float64) = "Having fun!"
 
-julia> check(Duck)
+julia> @check(Duck)
 ✅ Duck has implemented:
 1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -6,20 +6,20 @@
 @trait
 @assign
 @implement
+@check
 ```
 ## Functions
 
 ```@docs
 traits
-check
-required_contracts
 istrait
+required_contracts
 ```
 
 ## Types
 
 ```@docs
-BinaryTraits.InterfaceReview
 BinaryTraits.Assignable
 BinaryTraits.Contract
+BinaryTraits.InterfaceReview
 ```

--- a/examples/abstract_array.jl
+++ b/examples/abstract_array.jl
@@ -29,35 +29,36 @@ const IntVarArg = Vararg{Int, N} where N
 const Array1DInt = Array{Int,1}
 
 @assign Array1DInt with Dimension
-check(typeof(Array1DInt))
+@check(Array1DInt)
 #=
-julia> check(typeof(int_array))
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
 1. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+
 =#
 
 @assign Array1DInt with LinearIndexing
-check(typeof(Array1DInt))
+@check(Array1DInt)
 #=
-julia> check(typeof(int_array))
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
-1. LinearIndexingTrait: IsLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: IsLinearIndexing ⇢ setindex!(::<Type>, ::Int64)::Any
+1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
+2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
 3. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
 =#
 
 # 1D array is a specialized version of CartesianIndexing.
 # Let's verify.
 @assign Array1DInt with CartesianIndexing
-check(Array1DInt)
+@check(Array1DInt)
 #=
-julia> check(Array1DInt)
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
-1. LinearIndexingTrait: IsLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: IsLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
-3. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
+2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
+3. CartesianIndexingTrait: HasCartesianIndexing ⇢ getindex(::<Type>, ::Vararg{Int64,N} where N)::Any
 4. CartesianIndexingTrait: HasCartesianIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Vararg{Int64,N} where N)::Any
-5. CartesianIndexingTrait: HasCartesianIndexing ⇢ getindex(::<Type>, ::Vararg{Int64,N} where N)::Any
+5. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
 =#
 
 # -----------------------------------------------------------------------------
@@ -72,11 +73,11 @@ Base.size(S::SquaresVector) = (S.count,)
 Base.getindex(S::SquaresVector, i::Int) = i*i
 
 @assign SquaresVector with Dimension,LinearIndexing
-check(SquaresVector)
+@check(SquaresVector)
 #=
-julia> check(SquaresVector)
+julia> @check(SquaresVector)
 ✅ SquaresVector has implemented:
-1. LinearIndexingTrait: IsLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: IsLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
+1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
+2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
 3. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
 =#

--- a/examples/iteration_indexing.jl
+++ b/examples/iteration_indexing.jl
@@ -19,12 +19,12 @@ Base.iterate(S::Squares, state=1) = state > S.count ? nothing : (state*state, st
 
 # Let's assign the Squares type to Iterable
 @assign Squares with Iterable
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
+julia> @check(Squares)
 ✅ Squares has implemented:
-1. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-2. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
 =#
 
 # -----------------------------------------------------------------------------
@@ -48,38 +48,42 @@ function Base.getindex(S::Squares, i)
 end
 
 @assign Squares with Indexable
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
 ✅ Squares has implemented:
-1. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
+1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
 2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-3. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+3. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
 =#
 
 # We want to have the traits for indexing from beginning and at the end
 @assign Squares with IndexableFromBeginning, IndexableAtTheEnd
-check(Squares)
+@check(Squares)
 #=
+julia> @check(Squares)
+┌ Warning: Missing implementation: IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::Squares)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+┌ Warning: Missing implementation: IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::Squares)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
 ✅ Squares has implemented:
-1. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
+1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
 2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-3. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+3. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
 ❌ Squares is missing these implementations:
-1. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
-2. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::<Type>)::Any
+1. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::<Type>)::Any
+2. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
 =#
 
 # Let's implement them now.
 Base.firstindex(S::Squares) = 1
 Base.lastindex(S::Squares) = length(S)
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
+julia> @check(Squares)
 ✅ Squares has implemented:
-1. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
-2. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
+1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
 3. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::<Type>)::Any
-4. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-5. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
+4. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
+5. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
 =#

--- a/examples/user_guide_example.jl
+++ b/examples/user_guide_example.jl
@@ -1,0 +1,33 @@
+# Quick example
+
+using Revise, BinaryTraits
+
+abstract type Ability end
+@trait Fly as Ability
+@trait Swim as Ability
+@trait FlySwim with Fly,Swim
+@info "prefix and composite maps"  __binarytraits_prefix_map __binarytraits_composite_trait_map
+
+struct Crane end
+@assign Crane with Fly,Swim
+@info "traits" __binarytraits_traits_map
+
+@implement CanFly by liftoff()
+@implement CanFly by fly(direction::Float64, altitude::Float64)
+@implement CanFly by speed()::Float64
+@info "interface" __binarytraits_interface_map[CanFly]
+
+@check(Crane)
+#=
+julia> @check(Crane)
+┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ speed(::Crane)::Float64
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ liftoff(::Crane)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Crane, ::Float64, ::Float64)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+❌ Crane is missing these implementations:
+1. FlyTrait: CanFly ⇢ speed(::<Type>)::Float64
+2. FlyTrait: CanFly ⇢ liftoff(::<Type>)::Any
+3. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
+=#

--- a/examples/user_guide_example.jl
+++ b/examples/user_guide_example.jl
@@ -6,16 +6,13 @@ abstract type Ability end
 @trait Fly as Ability
 @trait Swim as Ability
 @trait FlySwim with Fly,Swim
-@info "prefix and composite maps"  __binarytraits_prefix_map __binarytraits_composite_trait_map
 
 struct Crane end
 @assign Crane with Fly,Swim
-@info "traits" __binarytraits_traits_map
 
 @implement CanFly by liftoff()
 @implement CanFly by fly(direction::Float64, altitude::Float64)
 @implement CanFly by speed()::Float64
-@info "interface" __binarytraits_interface_map[CanFly]
 
 @check(Crane)
 #=

--- a/src/BinaryTraits.jl
+++ b/src/BinaryTraits.jl
@@ -2,12 +2,14 @@ module BinaryTraits
 
 using MacroTools
 
-export @trait, @assign, @implement
-export traits, istrait, check, required_contracts
+export @trait, @assign, @implement, @check
+export istrait, traits, required_contracts
 
+include("types.jl")
 include("misc.jl")
 include("utils.jl")
 include("trait.jl")
+include("assignment.jl")
 include("interface.jl")
 
 end # module

--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -1,0 +1,100 @@
+
+"Create a new traits map"
+make_traits_map() = TraitsMap()
+
+"Get a reference to the module's composite trait map."
+function get_traits_map(m::Module)
+    isdefined(m, :__binarytraits_traits_map) || error("Bug, traits map is missing.")
+    return m.__binarytraits_traits_map
+end
+
+"""
+    traits(m::Module, T::Assignable)
+
+Returns a set of Can-types that the data type `T` exhibits.  Look through
+the composite traits and return the union of all Can-types as such.
+See also [`@assign`](@ref).
+"""
+function traits(m::Module, T::Assignable)
+    traits_map = get_traits_map(m)
+    base = get!(traits_map, T) do; Set{DataType}() end
+    for (Tmap, s) in pairs(traits_map)
+        if T !== Tmap && T <: Tmap
+            union!(base, s)
+        end
+    end
+    return base
+end
+
+"""
+    assign(m::Module, T::Assignable, can_type::DataType)
+
+Assign data type `T` with the specified Can-type from a trait.
+"""
+function assign(m::Module, T::Assignable, can_type::DataType)
+    traits_map = get_traits_map(m)
+    traits_set = get!(traits_map, T) do; Set{DataType}() end
+    push!(traits_set, can_type)
+    return nothing
+end
+
+
+"""
+    @assign <T> with <Trait1, Trait2, ...>
+
+Assign traits to the data type `T`.  For example:
+
+```julia
+@assign Duck with Fly,Swim
+```
+
+is translated to something like:
+
+```julia
+flytrait(::Duck) = CanFly()
+swimtrait(::Duck) = CanSwim()
+```
+
+where `x` is the name of the trait `X` in all lowercase, and `T` is the type
+being assigned with the trait `X`.
+"""
+macro assign(T::Symbol, with::Symbol, traits::Union{Expr,Symbol})
+    usage = "Invalid @assign usage.  Try something like: @assign Duck with Fly,Swim"
+    with === :with || throw(SyntaxError(usage))
+
+    expressions = Expr[]
+    trait_syms = traits isa Expr ? traits.args : [traits]
+    for t in trait_syms
+        trait_function = trait_func_name(t)
+        mod = __module__
+        this_can_type = can_type_symbol(mod, t)
+
+        # Add an expression like: <trait>trait(::T) = Can<Trait>()
+        # e.g. flytrait(::Duck) = CanFly()
+        push!(expressions,
+            Expr(:(=),
+                Expr(:call, trait_function, Expr(:(::), T)),
+                Expr(:call, this_can_type)))
+
+        # e.g. BinaryTraits.assign(MyModule, Duck, CanFly)
+        push!(expressions,
+                quote
+                    BinaryTraits.assign($mod, $T, $this_can_type)
+                end)
+    end
+
+    expr = quote
+        # ensure that traits map is allocated
+        global __binarytraits_traits_map
+        if !@isdefined(__binarytraits_traits_map)
+            __binarytraits_traits_map = BinaryTraits.make_traits_map()
+        end
+        # call assign function
+        $(expressions...)
+        nothing
+    end
+
+    display_expanded_code(expr)
+    return esc(expr)
+end
+

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -82,7 +82,7 @@ function check(m::Module, T::Assignable)
             end
         end
     end
-    return InterfaceReview(type = T, result = all_good,
+    return InterfaceReview(data_type = T, result = all_good,
                 implemented = implemented_contracts,
                 misses = missing_contracts)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,179 +1,75 @@
 # used for display purpose only
 const TYPE_PLACEHOLDER = "::<Type>"
 
-"""
-    traits_map
+"Create a new interface map"
+make_interface_map() = InterfaceMap()
 
-The `traits_map` maps a data type to the Can-type of the asigned traits.
 
-For example, the `Duck` and `Dog` types and then assign them with `Fly`
-and `Swim` traits.  The map would look like this:
-
-```julia
-julia> BinaryTraits.traits_map
-Dict{Union{DataType, UnionAll},Set{DataType}} with 2 entries:
-  Dog  => Set(DataType[CanSwim])
-  Duck => Set(DataType[CanSwim, CanFly])
-```
-"""
-const traits_map = Dict{Assignable,Set{DataType}}()
-
-"""
-    traits(T::Assignable)
-
-Returns a set of Can-types that the data type `T` exhibits.
-See also [`@assign`](@ref).
-"""
-function traits(T::Assignable)
-    base = get!(traits_map, T) do; Set{DataType}() end
-    for (Tmap, s) in pairs(traits_map)
-        if T !== Tmap && T <: Tmap
-            union!(base, s)
-        end
-    end
-    return base
+"Get a reference to the module's interface map."
+function get_interface_map(m::Module)
+    isdefined(m, :__binarytraits_interface_map) || error("Bug, interface map is missing.")
+    return m.__binarytraits_interface_map
 end
 
 """
-    assign(T::Assignable, can_type::DataType)
-
-Assign data type `T` with the specified Can-type of a trait.
-"""
-function assign(T::Assignable, can_type::DataType)
-    traits_set = get!(traits_map, T) do; Set{DataType}() end
-    push!(traits_set, can_type)
-    return nothing
-end
-
-# Managing interface contracts
-
-"""
-    Contract{T <: DataType, F <: Function, N}
-
-A contract refers to a function defintion `func` that is required to satisfy
-the Can-type of a trait. The function `func` must accepts `args` and returns `ret`.
-
-# Fields
-- `can_type`: can-type of a trait e.g. `CanFly`
-- `func`: function that must be implemented to satisfy this trait
-- `args`: argument types of the function `func`
-- `kwargs`: keyword argument names of the function `func`
-- `ret`: return type of the function `func`
-"""
-struct Contract{T <: DataType, F <: Function}
-    can_type::T
-    func::F
-    args::Tuple
-    kwargs::Tuple
-    ret::Union{DataType,Nothing}
-end
-
-function Base.show(io::IO, c::Contract)
-    typ = Symbol(TYPE_PLACEHOLDER)
-    args = string("(", join([typ, c.args...], ", ::"))
-    if length(c.kwargs) > 0
-        args = string(args, "; ", join(c.kwargs, ", "))
-    end
-    args = string(args, ")")
-    trait = supertype(c.can_type)
-    print(io, "$(trait): $(c.can_type) ⇢ $(c.func)$(args)")
-    c.ret !== nothing && print(io, "::$(c.ret)")
-end
-
-"""
-    interface_map
-
-The `interface_map` maps a data type to a set of Contracts.
-"""
-const interface_map = Dict{DataType,Set{Contract}}()
-
-"""
-    register(can_type::DataType, func::Function, args::NTuple{N,DataType}, ret::DataType) where N
+    register(m::Module, can_type::DataType, func::Function, args::NTuple{N,DataType},
+             kwargs::NTuple{N,Symbol}, ret::DataType) where N
 
 Register a function `func` with the specified `can_type` type.
-The `func` is expected to take arguments `args` and return
-a value of type `ret`.
+The `func` is expected to take arguments `args` and keyword arguments `kwargs`
+and return a value of type `ret`.
 """
-function register(can_type::DataType,
+function register(m::Module,
+                  can_type::DataType,
                   func::Function,
                   args::Tuple,
                   kwargs::NTuple{N,Symbol},
                   ret::Union{DataType,Nothing} = nothing) where N
+    interface_map = get_interface_map(m)
     contracts = get!(interface_map, can_type) do; Set{Contract}() end
     push!(contracts, Contract(can_type, func, args, kwargs, ret))
     return nothing
 end
 
 """
-    contracts(can_type::DataType)
+    contracts(m::Module, can_type::DataType)
 
-Returns a set of Contracts that are required to be implemented
-for `can_type`.
+Returns a set of [`Contracts`](@ref) that are required to be implemented
+for objects that exihibits the specific `can_type` trait.
 """
-function contracts(can_type::DataType)
+function contracts(m::Module, can_type::DataType)
+    interface_map = get_interface_map(m)
+    composite_traits = get_composite_trait_map(m)
     current_contracts = get(interface_map, can_type, Set{Contract}())
     if haskey(composite_traits, can_type)
-        contracts_array = contracts.(composite_traits[can_type])
-        @debug "after recusion" contracts_array
+        contracts_array = contracts.(Ref(m), composite_traits[can_type])
         underlying_contracts = union(contracts_array...)
-        @debug "combining" current_contracts underlying_contracts
         return union(current_contracts, underlying_contracts)
     else
-        @debug "returning" current_contracts
         return current_contracts
     end
 end
 
+# Convenience macro so the client does not need to provide module argument
 """
-    InterfaceReview
-
-An InterfaceReview object contains the validation results of an interface.
-
-# Fields
-- `type`: the type being checked
-- `result`: true if the type fully implements all required contracts
-- `implemented`: an array of implemented contracts
-- `misses`: an array of unimplemented contracts
-"""
-@Base.kwdef struct InterfaceReview
-    type::Assignable
-    result::Bool
-    implemented::Vector{Contract}
-    misses::Vector{Contract}
-end
-
-function Base.show(io::IO, ir::InterfaceReview)
-    T = InterfaceReview
-    irtype = ir.type
-    if length(ir.implemented) == length(ir.misses) == 0
-        print(io, "✅ $(irtype) has no interface contract requirements.")
-    end
-    if length(ir.implemented) > 0
-        println(io, "✅ $(irtype) has implemented:")
-        for (i, c) in enumerate(ir.implemented)
-            println(io, "$(i). $c")
-        end
-    end
-    if length(ir.misses) > 0
-        println(io, "❌ $(irtype) is missing these implementations:")
-        for (i, c) in enumerate(ir.misses)
-            println(io, "$(i). $c")
-        end
-    end
-end
-
-"""
-    check(T::Assignable)
+    @check(T::Assignable)
 
 Check if the data type `T` has fully implemented all trait functions that it was
 previously assigned.  See also: [`@assign`](@ref).
 """
-function check(T::Assignable)
+macro check(T)
+    mod = __module__
+    return esc(quote
+        BinaryTraits.check($mod, $T)
+    end)
+end
+
+function check(m::Module, T::Assignable)
     all_good = true
     implemented_contracts = Contract[]
     missing_contracts = Contract[]
-    for can_type in traits(T)
-        for c in contracts(can_type)
+    for can_type in traits(m, T)
+        for c in contracts(m, can_type)
             tuple_type = Tuple{T, c.args...}
             method_exists = has_method(c.func, tuple_type, c.kwargs)
             sig = replace("$c", TYPE_PLACEHOLDER => "::$T")
@@ -192,13 +88,13 @@ function check(T::Assignable)
 end
 
 """
-    required_contracts(T::Assignable)
+    required_contracts(m::Module, T::Assignable)
 
 Return a set of contracts that is required to be implemented for
 the provided type `T`.
 """
-function required_contracts(T::Assignable)
-    c = [contracts(t) for t in traits(T)]  # returns array of set of contracts
+function required_contracts(m::Module, T::Assignable)
+    c = [contracts(m, t) for t in traits(m, T)]  # returns array of set of contracts
     return union(c...)
 end
 
@@ -232,12 +128,21 @@ macro implement(can_type, by, sig)
     func_name, func_arg_names, func_arg_types, kwarg_names, return_type =
         parse_implement(can_type, by, sig)
     # @info "sig" func_name func_arg_names func_arg_types
-    
+
     kwtuple = tuple(kwarg_names...)
+    mod = __module__
+
     # generate code
     expr = quote
         function $func_name end
-        BinaryTraits.register($can_type, $func_name,
+
+        # Keep copy of interface map in client module
+        global __binarytraits_interface_map
+        if !@isdefined(__binarytraits_interface_map)
+            __binarytraits_interface_map = BinaryTraits.make_interface_map()
+        end
+
+        BinaryTraits.register($mod, $can_type, $func_name,
                               ($(func_arg_types...),), $kwtuple, $return_type)
     end
     display_expanded_code(expr)
@@ -250,7 +155,7 @@ function parse_implement(can_type, by, sig)
     can_type isa Symbol && sig isa Expr && by === :by || throw(SyntaxError(usage))
 
     # Is return type specified?
-    if sig.head === Symbol("::") 
+    if sig.head === Symbol("::")
         return_type = sig.args[2]
         sig = sig.args[1]
     else

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,20 +1,8 @@
-"""
-    Assignable
-
-`Assignable` represents any data type that can be associated with traits.
-It essentially covers all data types including parametric types e.g. `AbstractArray`
-"""
-const Assignable = Union{UnionAll, DataType}
-
-
-struct SyntaxError <: Exception
-    msg
-end
 
 # verbose flag
 
 const VERBOSE = Ref(false)
 
-function set_verbose(b::Bool)
-    VERBOSE[] = b
+function set_verbose(verbose::Bool)
+    VERBOSE[] = verbose
 end

--- a/src/trait.jl
+++ b/src/trait.jl
@@ -21,11 +21,9 @@ prefixes(m::Module, trait::Symbol) = get_prefix_map(m)[trait]
 
 # :Fly => :Can
 can_prefix(m::Module, trait::Symbol) = prefixes(m, trait)[1]
-cannot_prefix(m::Module, trait::Symbol) = prefixes(m, trait)[2]
 
 # :Fly => :CanFly
 can_type_symbol(m::Module, trait::Symbol) = Symbol(String(can_prefix(m, trait)) * String(trait))
-cannot_type_symbol(m::Module, trait::Symbol) = Symbol(String(can_prefix(m, trait)) * String(trait))
 
 # -----------------------------------------------------------------------------
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -45,13 +45,13 @@ end
 An InterfaceReview object contains the validation results of an interface.
 
 # Fields
-- `type`: the type being checked
+- `data_type`: the type being checked
 - `result`: true if the type fully implements all required contracts
 - `implemented`: an array of implemented contracts
 - `misses`: an array of unimplemented contracts
 """
 @Base.kwdef struct InterfaceReview
-    type::Assignable
+    data_type::Assignable
     result::Bool
     implemented::Vector{Contract}
     misses::Vector{Contract}
@@ -59,7 +59,7 @@ end
 
 function Base.show(io::IO, ir::InterfaceReview)
     T = InterfaceReview
-    irtype = ir.type
+    irtype = ir.data_type
     if length(ir.implemented) == length(ir.misses) == 0
         print(io, "✅ $(irtype) has no interface contract requirements.")
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,118 @@
+"""
+    Assignable
+
+`Assignable` represents any data type that can be associated with traits.
+It essentially covers all data types including parametric types e.g. `AbstractArray`
+"""
+const Assignable = Union{UnionAll, DataType}
+
+"""
+    Contract{T <: DataType, F <: Function, N}
+
+A contract refers to a function defintion `func` that is required to satisfy
+the Can-type of a trait. The function `func` must accepts `args` and returns `ret`.
+
+# Fields
+- `can_type`: can-type of a trait e.g. `CanFly`
+- `func`: function that must be implemented to satisfy this trait
+- `args`: argument types of the function `func`
+- `kwargs`: keyword argument names of the function `func`
+- `ret`: return type of the function `func`
+"""
+struct Contract{T <: DataType, F <: Function}
+    can_type::T
+    func::F
+    args::Tuple
+    kwargs::Tuple
+    ret::Union{DataType,Nothing}
+end
+
+function Base.show(io::IO, c::Contract)
+    typ = Symbol(TYPE_PLACEHOLDER)
+    args = string("(", join([typ, c.args...], ", ::"))
+    if length(c.kwargs) > 0
+        args = string(args, "; ", join(c.kwargs, ", "))
+    end
+    args = string(args, ")")
+    trait = supertype(c.can_type)
+    print(io, "$(trait): $(c.can_type) ⇢ $(c.func)$(args)")
+    c.ret !== nothing && print(io, "::$(c.ret)")
+end
+
+"""
+    InterfaceReview
+
+An InterfaceReview object contains the validation results of an interface.
+
+# Fields
+- `type`: the type being checked
+- `result`: true if the type fully implements all required contracts
+- `implemented`: an array of implemented contracts
+- `misses`: an array of unimplemented contracts
+"""
+@Base.kwdef struct InterfaceReview
+    type::Assignable
+    result::Bool
+    implemented::Vector{Contract}
+    misses::Vector{Contract}
+end
+
+function Base.show(io::IO, ir::InterfaceReview)
+    T = InterfaceReview
+    irtype = ir.type
+    if length(ir.implemented) == length(ir.misses) == 0
+        print(io, "✅ $(irtype) has no interface contract requirements.")
+    end
+    if length(ir.implemented) > 0
+        println(io, "✅ $(irtype) has implemented:")
+        for (i, c) in enumerate(ir.implemented)
+            println(io, "$(i). $c")
+        end
+    end
+    if length(ir.misses) > 0
+        println(io, "❌ $(irtype) is missing these implementations:")
+        for (i, c) in enumerate(ir.misses)
+            println(io, "$(i). $c")
+        end
+    end
+end
+
+"""
+    SyntaxError
+
+Syntax error for macros.
+"""
+struct SyntaxError <: Exception
+    msg
+end
+
+"""
+    TraitsMap
+
+Map a data type to the Can-type of its assigned traits.
+For example, `Dog => Set([CanSwim, CanRun])`.
+"""
+const TraitsMap = Dict{Assignable,Set{DataType}}
+
+"""
+    InterfaceMap
+
+Map a Can-type to a set of interface contracts.  See [`Contract`](@ref).
+"""
+const InterfaceMap = Dict{DataType,Set{Contract}}
+
+"""
+    PrefixMap
+
+Maps a prefix symbol to the positive/negatiave prefix symbols
+e.g. `:Fly => (:Can, :Cannot)`.
+"""
+const PrefixMap = Dict{Symbol,Tuple{Symbol,Symbol}}
+
+"""
+    CompositeTraitMap
+
+Maps a composite can-type to a set of its underlying can-types.
+e.g. `CanFlySwim => Set([CanFly, CanSwim])`.
+"""
+const CompositeTraitMap = Dict{DataType,Set{DataType}}

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,10 +58,10 @@ An InterfaceReview object contains the validation results of an interface.
 end
 
 function Base.show(io::IO, ir::InterfaceReview)
-    T = InterfaceReview
     irtype = ir.data_type
     if length(ir.implemented) == length(ir.misses) == 0
         print(io, "✅ $(irtype) has no interface contract requirements.")
+        return
     end
     if length(ir.implemented) > 0
         println(io, "✅ $(irtype) has implemented:")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,7 @@ module Interfaces
     # no contract requirements (code coverage)
     struct Kiwi end
 
-    # weird argument types in contract specs 
+    # weird argument types in contract specs
     @trait Creep
     @implement CanCreep by creep1(a::Int=5) # argument assignment
     @implement CanCreep by creep2({}) # invalid argument
@@ -224,37 +224,37 @@ module Interfaces
     function test()
         @testset "Interface validation" begin
 
-            bird_check = check(Bird)
+            bird_check = @check(Bird)
             @test bird_check.result == true
             @test bird_check.implemented |> length == 3
             @test bird_check.misses |> length == 0
 
-            chicken_check = check(Chicken)
+            chicken_check = @check(Chicken)
             @test chicken_check.result == false
             @test chicken_check.implemented |> length == 0
             @test chicken_check.misses |> length == 3
 
-            duck_check = check(Duck)
+            duck_check = @check(Duck)
             @test duck_check.result == false
             @test duck_check.implemented |> length == 1
             @test duck_check.misses |> length == 2
 
-            flamingo_check = check(Flamingo)
+            flamingo_check = @check(Flamingo)
             @test flamingo_check.result == true
             @test flamingo_check.implemented |> length == 4
             @test flamingo_check.misses |> length == 0
 
-            crane_check = check(Crane)
+            crane_check = @check(Crane)
             @test crane_check.result == false
             @test crane_check.implemented |> length == 3
             @test crane_check.misses |> length == 1
 
-            penguin_check = check(Penguin)
+            penguin_check = @check(Penguin)
             @test penguin_check.result == false
             @test penguin_check.implemented |> length == (SUPPORT_KWARGS ? 7 : 4)
             @test penguin_check.misses |> length == (SUPPORT_KWARGS ? 2 : 1)
 
-            rabbit_check = check(Rabbit)
+            rabbit_check = @check(Rabbit)
             @test rabbit_check.result == true
 
             # test `show` function
@@ -271,10 +271,10 @@ module Interfaces
             @test buf |> take! |> String |> contains("is missing")
 
             # Bird is assigned with 1 FlyTrait and that requires 3 contracts
-            @test required_contracts(Bird) |> length == 3
+            @test required_contracts(@__MODULE__, Bird) |> length == 3
 
             # Crane requires 4 contracts because it has both Fly and Pretty traits
-            @test required_contracts(Crane) |> length == 4
+            @test required_contracts(@__MODULE__, Crane) |> length == 4
 
             # Penguin
             if SUPPORT_KWARGS
@@ -285,13 +285,13 @@ module Interfaces
             @test buf |> take! |> String |> contains("dive6")
 
             # has no interface requirements
-            check_kiwi = check(Kiwi)
+            check_kiwi = @check(Kiwi)
             @test check_kiwi.result
             show(buf, check_kiwi)
             @test buf |> take! |> String |> contains("has no interface contract")
 
             # strange argument types are both accepted
-            check_snake = check(Snake)
+            check_snake = @check(Snake)
             @test check_snake.result
             @test check_snake.implemented |> length == 2
 
@@ -315,6 +315,7 @@ module Verbose
         end)
     end
 
+    @trait Scratch
     struct Cat end
 
     # Testing verbose mode


### PR DESCRIPTION
1. Maintain dict's (eg. prefix and interface map) at client module
2. Breaking change - `@check` macro is replacing `check` function for users
3. Updated all doc strings and documentation
4. Moved coded around, hence added types.jl and assignment.jl

Fixes #37.

Cc: @KlausC - any thoughts?