### PR TITLE
global storage in BinaryTraits

### DIFF
--- a/src/BinaryTraits.jl
+++ b/src/BinaryTraits.jl
@@ -2,8 +2,9 @@ module BinaryTraits
 
 using MacroTools
 
-export @trait, @assign, @implement
+export @trait, @assign, @implement, @check
 export check, istrait, traits, required_contracts
+export inittraits
 
 include("types.jl")
 include("misc.jl")

--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -1,17 +1,4 @@
 
-"Create a new traits map"
-make_traits_map() = TraitsMap()
-const EMPTY_TRAITS_MAP = Dict{Assignable,Set{DataType}}()
-
-"Get a reference to the module's composite trait map."
-function get_traits_map(m::Module)
-    if isdefined(m, :__binarytraits_traits_map)
-        m.__binarytraits_traits_map
-    else
-        EMPTY_TRAITS_MAP
-    end
-end
-
 """
     traits(m::Module, T::Assignable)
 
@@ -36,9 +23,7 @@ end
 Assign data type `T` with the specified Can-type from a trait.
 """
 function assign(m::Module, T::Assignable, can_type::DataType)
-    traits_map = get_traits_map(m)
-    traits_set = get!(traits_map, T) do; Set{DataType}() end
-    push!(traits_set, can_type)
+    push_traits_map!(m, T, can_type)
     return nothing
 end
 
@@ -91,14 +76,7 @@ function assign_impl(mod, T, traits)
     end
 
     expr = quote
-        # ensure that traits map is allocated
-        global __binarytraits_traits_map
-        if !@isdefined(__binarytraits_traits_map)
-            __binarytraits_traits_map = BinaryTraits.make_traits_map()
-        end
-        # call assign function
         $(expressions...)
-        nothing
     end
 
     display_expanded_code(expr)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -15,6 +15,5 @@ end
 if VERSION < v"1.2.0"
     valtype(::Type{<:AbstractDict{K,V}}) where {K,V} = V
     valtype(::T) where T<:AbstractDict = valtype(T)
-    Base.get!(f, d::IdDict, key) = haskey(d, key) ? d[key] : f()
 end
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -11,9 +11,3 @@ function set_verbose(verbose::Bool)
     VERBOSE[] = verbose
 end
 
-# some standard methods which were introduced in v1.2
-if VERSION < v"1.2.0"
-    valtype(::Type{<:AbstractDict{K,V}}) where {K,V} = V
-    valtype(::T) where T<:AbstractDict = valtype(T)
-end
-

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,8 +1,20 @@
 
 # verbose flag
-
 const VERBOSE = Ref(false)
 
+"""
+    set_verbose(::Bool)
+
+For debugging - set flag to print macro expansions
+"""
 function set_verbose(verbose::Bool)
     VERBOSE[] = verbose
 end
+
+# some standard methods which were introduced in v1.2
+if VERSION < v"1.2.0"
+    valtype(::Type{<:AbstractDict{K,V}}) where {K,V} = V
+    valtype(::T) where T<:AbstractDict = valtype(T)
+    Base.get!(f, d::IdDict, key) = haskey(d, key) ? d[key] : f()
+end
+

--- a/src/types.jl
+++ b/src/types.jl
@@ -108,3 +108,19 @@ Maps a composite can-type to a set of its underlying can-types.
 e.g. `CanFlySwim => Set([CanFly, CanSwim])`.
 """
 const CompositeTraitMap = Dict{DataType,Set{DataType}}
+
+"""
+    TraitsStorage
+
+Type keeping all traits-related dynamic data.
+[`TraitsMap`](@ref)
+[`InterfaceMap`](@ref)
+[`CompositeTraitMap`](@ref)
+"""
+struct TraitsStorage
+    traits_map::TraitsMap
+    interface_map::InterfaceMap
+    composite_map::CompositeTraitMap
+    TraitsStorage() = new(TraitsMap(), InterfaceMap(), CompositeTraitMap())
+end
+

--- a/src/types.jl
+++ b/src/types.jl
@@ -92,14 +92,14 @@ end
 Map a data type to the Can-type of its assigned traits.
 For example, `Dog => Set([CanSwim, CanRun])`.
 """
-const TraitsMap = Dict{Assignable,Set{DataType}}
+const TraitsMap = IdDict{Assignable,Set{DataType}}
 
 """
     InterfaceMap
 
 Map a Can-type to a set of interface contracts.  See [`Contract`](@ref).
 """
-const InterfaceMap = Dict{DataType,Set{Contract}}
+const InterfaceMap = IdDict{DataType,Set{Contract}}
 
 """
     CompositeTraitMap
@@ -107,7 +107,7 @@ const InterfaceMap = Dict{DataType,Set{Contract}}
 Maps a composite can-type to a set of its underlying can-types.
 e.g. `CanFlySwim => Set([CanFly, CanSwim])`.
 """
-const CompositeTraitMap = Dict{DataType,Set{DataType}}
+const CompositeTraitMap = IdDict{DataType,Set{DataType}}
 
 """
     TraitsStorage

--- a/src/types.jl
+++ b/src/types.jl
@@ -86,20 +86,22 @@ struct SyntaxError <: Exception
     msg
 end
 
+const MyDict = VERSION < v"1.2.0" ? Dict : IdDict
+
 """
     TraitsMap
 
 Map a data type to the Can-type of its assigned traits.
 For example, `Dog => Set([CanSwim, CanRun])`.
 """
-const TraitsMap = IdDict{Assignable,Set{DataType}}
+const TraitsMap = MyDict{Assignable,Set{DataType}}
 
 """
     InterfaceMap
 
 Map a Can-type to a set of interface contracts.  See [`Contract`](@ref).
 """
-const InterfaceMap = IdDict{DataType,Set{Contract}}
+const InterfaceMap = MyDict{DataType,Set{Contract}}
 
 """
     CompositeTraitMap
@@ -107,7 +109,7 @@ const InterfaceMap = IdDict{DataType,Set{Contract}}
 Maps a composite can-type to a set of its underlying can-types.
 e.g. `CanFlySwim => Set([CanFly, CanSwim])`.
 """
-const CompositeTraitMap = IdDict{DataType,Set{DataType}}
+const CompositeTraitMap = MyDict{DataType,Set{DataType}}
 
 """
     TraitsStorage

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -133,6 +133,8 @@ push_composite_map!(m::Module, a::DataType, val) = pushdict!(m, :composite_map, 
 push_or_union!(s::Set, val) = push!(s, val)
 push_or_union!(s::Set, val::Set) = union!(s, val)
 
+import Base.rehash!
+
 """
     move_to_global!(module)
 
@@ -141,6 +143,7 @@ Afterwared the local storage is emty.
 """
 function move_to_global!(mod::Module)
     st = get_local_storage(mod)
+    rehash!(st)
     if st !== nothing && !isempty(st)
         for sym in (:traits_map, :interface_map, :composite_map)
             dtab = getproperty(storage(), sym)
@@ -167,6 +170,12 @@ function inittraits(mod::Module)
     move_to_global!(mod)
 end
 
+function rehash!(st::TraitsStorage)
+    rehash!(st.traits_map)
+    rehash!(st.interface_map)
+    rehash!(st.composite_map)
+    return st
+end
 function Base.isempty(st::TraitsStorage)
     isempty(st.traits_map) &&
     isempty(st.interface_map) &&

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,3 +60,111 @@ function display_expanded_code(expr::Expr)
     return nothing
 end
 
+# some standard methods which were introduced in v1.2
+if VERSION < v"1.2.0"
+    valtype(::Type{<:AbstractDict{K,V}}) where {K,V} = V
+    valtype(::T) where T<:AbstractDict = valtype(T)
+    Base.get!(f, d::IdDict, key) = haskey(d, key) ? d[key] : f()
+end
+
+define_const!(mod::Module, name::Symbol, val) = mod.eval( :(const $name = $val) )
+define_var!(mod::Module, name::Symbol, val) = mod.eval( :($name = $val) )
+
+# Storage management
+
+const TRAITS_STORAGE = TraitsStorage() # the singleton global storage
+storage() = TRAITS_STORAGE
+
+"""
+    make_local_storage(module)
+
+Create a temporary variable with a `TraitsStorage` object in given module.
+"""
+function make_local_storage(mod::Module)
+    if !isdefined(mod, :__binarytraits_storage)
+        mod.eval( :( const __binarytraits_storage = BinaryTraits.TraitsStorage()) )
+    end
+    mod.__binarytraits_storage
+end
+
+function get_local_storage(mod::Module)
+    isdefined(mod, :__binarytraits_storage) ? mod.__binarytraits_storage : nothing
+end
+
+"""
+    getvalues(module, :table, key)
+
+Get the set of values associated with the `key` in field `table`.
+Try first local (module-) table, if key not found use global table
+"""
+function getvalues(mod::Module, sym::Symbol, key)
+    st = get_local_storage(mod)
+    if st != nothing
+        tab = getproperty(st, sym)
+        haskey(tab, key) && return tab[key]
+    end
+    tab = getproperty(storage(), sym)
+    return haskey(tab, key) ? tab[key] : valtype(tab)()
+end
+get_traits_values(m::Module, key::Assignable) = getvalues(m, :traits_map, key)
+get_interface_values(m::Module, key::DataType) = getvalues(m, :interface_map, key)
+get_composite_values(m::Module, key::DataType) = getvalues(m, :composite_map, key)
+
+function get_traits_map(mod::Module)
+    lst = make_local_storage(mod)
+    gst = storage()
+    return lst === nothing ? gst.traits_map : merge(union, gst.traits_map, lst.traits_map)
+end
+
+"""
+    pushdict!(module, :table, key, value)
+
+Insert value into set associated with `key` in the local (module-) `table`.
+Create set if not pre-existent.
+"""
+function pushdict!(mod::Module, sym::Symbol, key, val)
+    st = make_local_storage(mod)
+    tab = getproperty(st, sym)
+    s = get!(valtype(tab), tab, key)
+    push_or_union!(s, val)
+    return
+end
+push_traits_map!(m::Module, a::Assignable, val) = pushdict!(m, :traits_map, a, val)
+push_interface_map!(m::Module, a::DataType, val) = pushdict!(m, :interface_map, a, val)
+push_composite_map!(m::Module, a::DataType, val) = pushdict!(m, :composite_map, a, val)
+
+push_or_union!(s::Set, val) = push!(s, val)
+push_or_union!(s::Set, val::Set) = union!(s, val)
+
+"""
+    move_to_global!(module)
+
+Move all sets collected in local storage to global storage.
+Afterwared the local storage is emty.
+"""
+function move_to_global!(mod::Module)
+    st = get_local_storage(mod)
+    if st !== nothing
+        for sym in (:traits_map, :interface_map, :composite_map)
+            dtab = getproperty(storage(), sym)
+            stab = getproperty(st, sym)
+            for (key, vset) in stab
+                dset = get!(valtype(stab), dtab, key)
+                union!(dset, vset)
+            end
+            empty!(stab)
+        end
+    end
+    return
+end
+
+"""
+    inittraits(module)
+
+This function should be called like `inittraits(@__MODULE__)` inside the
+`__init__()' method of each module using `BinaryTraits`.
+"""
+function inittraits(mod::Module)
+    move_to_global!(mod)
+end
+


### PR DESCRIPTION
Implement the ideas of a single global storage for all maps (`BinaryTraits.storage()`)
It allows to spread the use of all macros and functions of `BinaryTraits` to arbitrary packages and modules. No assumptions about which module contains the registration dictionaries are needed.

Implementation details:
During the processing of a module additional storage is used in module `<mod>.__binarytraits_storage`, which is moved to global storage `BinaryTraits.TRAITS_STORAGE` by `inittraits()` called in module initialization method `__init__()`.

After the module is included, all traits definitions made in the module are available in global store.
This works well with precompiled packages.