### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fly(::Bird, destination::Location, speed::Float64) = "Wohoo! Arrived! 🐦"
 @assign Bird with CanFly
 
 # Verify that your implementation is correct
-check(Bird)
+@check(Bird)
 ```
 
 ## Main Features

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Travis Build Status](https://travis-ci.org/tk3369/BinaryTraits.jl.svg?branch=master)](https://travis-ci.org/tk3369/BinaryTraits.jl)
 [![codecov.io](http://codecov.io/github/tk3369/BinaryTraits.jl/coverage.svg?branch=master)](http://codecov.io/github/tk3369/BinaryTraits.jl?branch=master)
 
+*NOTE: This package is quite functional already but still experimental in the
+sense that more breaking changes are expected.  Follow the
+[issues list](https://github.com/tk3369/BinaryTraits.jl/issues)
+if you are interested in the ongoing progress.*
 
 BinaryTraits.jl focuses on usability - traits should be simple to understand and easy to use.
 For that reason, it is designed to be an *opinionated* library and follows certain conventions.

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -1,5 +1,3 @@
-# Under the hood
-
 The underlying machinery is extremely simple. When you define a traits like `@trait Fly as Ability`, it literally expands to the following code:
 
 ```julia
@@ -11,7 +9,7 @@ flytrait(x) = CannotFly()
 
 As you can see, our *opinion* is to define a new abstract type called  `FlyTrait`.  Likewise, we define `CanFly` and `CannotFly` subtypes.  Finally, we define a default trait function `flytrait` that just returns an instance of `CannotFly`.  Hence, all data types are automatically defined from the trait by default.
 
-Now, when you do `@assign Duck with Fly,Swim`, it is just translated to:
+Now, when you do `@assign Duck with CanFly,CanSwim`, it is just translated to:
 
 ```julia
 flytrait(::Duck) = CanFly()

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,8 +24,8 @@ Consider the following animal types. We can assign them traits quite easily:
 ```@example ex
 struct Dog end
 struct Duck end
-@assign Dog with Swim
-@assign Duck with Swim,Fly
+@assign Dog with CanSwim
+@assign Duck with CanSwim,CanFly
 nothing # hide
 ```
 
@@ -56,11 +56,11 @@ implement a `fly` method.  We can define that interface as follows:
 @implement CanFly by fly(direction::Float64, altitude::Float64)
 ```
 
-Then, to make sure that our implementation is correct, we can use the `check`
+Then, to make sure that our implementation is correct, we can use the `@check`
 macro as shown below:
 
 ```julia
-julia> check(Duck)
+julia> @check(Duck)
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Duck, ::Float64, ::Float64)::Nothing
 └ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:170
 ❌ Duck is missing these implementations:
@@ -72,7 +72,7 @@ Now, let's implement the method and check again:
 ```julia
 julia> fly(duck::Duck, direction::Float64, altitude::Float64) = "Having fun!"
 
-julia> check(Duck)
+julia> @check(Duck)
 ✅ Duck has implemented:
 1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,4 +1,5 @@
-# Reference
+This page contains the most important macros, functions, and types
+that you should be aware of.
 
 ## Macros
 
@@ -6,14 +7,15 @@
 @trait
 @assign
 @implement
+@check
 ```
 ## Functions
 
 ```@docs
 traits
 istrait
-check
 required_contracts
+inittraits
 ```
 
 ## Types

--- a/examples/abstract_array.jl
+++ b/examples/abstract_array.jl
@@ -29,17 +29,17 @@ const IntVarArg = Vararg{Int, N} where N
 const Array1DInt = Array{Int,1}
 
 @assign Array1DInt with HasDimension
-check(Array1DInt)
+@check(Array1DInt)
 #=
-julia> check(Array1DInt)
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
 1. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
 =#
 
 @assign Array1DInt with HasLinearIndexing
-check(Array1DInt)
+@check(Array1DInt)
 #=
-julia> check(Array1DInt)
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
 1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
 2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
@@ -49,9 +49,9 @@ julia> check(Array1DInt)
 # 1D array is a specialized version of CartesianIndexing.
 # Let's verify.
 @assign Array1DInt with HasCartesianIndexing
-check(Array1DInt)
+@check(Array1DInt)
 #=
-julia> check(Array1DInt)
+julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
 1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
 2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
@@ -72,9 +72,9 @@ Base.size(S::SquaresVector) = (S.count,)
 Base.getindex(S::SquaresVector, i::Int) = i*i
 
 @assign SquaresVector with HasDimension,HasLinearIndexing
-check(SquaresVector)
+@check(SquaresVector)
 #=
-julia> check(SquaresVector)
+julia> @check(SquaresVector)
 ✅ SquaresVector has implemented:
 1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
 2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any

--- a/examples/iteration_indexing.jl
+++ b/examples/iteration_indexing.jl
@@ -19,9 +19,9 @@ Base.iterate(S::Squares, state=1) = state > S.count ? nothing : (state*state, st
 
 # Let's assign the Squares type to Iterable
 @assign Squares with IsIterable
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
+julia> @check(Squares)
 ✅ Squares has implemented:
 1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
 2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
@@ -48,7 +48,7 @@ function Base.getindex(S::Squares, i)
 end
 
 @assign Squares with IsIndexable
-check(Squares)
+@check(Squares)
 #=
 ✅ Squares has implemented:
 1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
@@ -58,9 +58,9 @@ check(Squares)
 
 # We want to have the traits for indexing from beginning and at the end
 @assign Squares with IsIndexableFromBeginning, IsIndexableAtTheEnd
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
+julia> @check(Squares)
 ┌ Warning: Missing implementation: IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::Squares)::Any
 └ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
 ┌ Warning: Missing implementation: IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::Squares)::Any
@@ -77,9 +77,9 @@ julia> check(Squares)
 # Let's implement them now.
 Base.firstindex(S::Squares) = 1
 Base.lastindex(S::Squares) = length(S)
-check(Squares)
+@check(Squares)
 #=
-julia> check(Squares)
+julia> @check(Squares)
 ✅ Squares has implemented:
 1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
 2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any

--- a/examples/user_guide_example.jl
+++ b/examples/user_guide_example.jl
@@ -17,9 +17,9 @@ struct Crane end
 @assign Crane with CanFly,CanSwim
 
 # Check compliance.
-check(Crane)
+@check(Crane)
 #=
-julia> check(Crane)
+julia> @check(Crane)
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ speed(::Crane)::Float64
 └ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ liftoff(::Crane)::Any
@@ -40,9 +40,9 @@ struct Swan end
 @assign Swan with CanFlySwim
 
 # Check compliance. It should drill down to figure out required interface contracts.
-check(Swan)
+@check(Swan)
 #=
-julia> check(Swan)
+julia> @check(Swan)
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Swan, ::Float64, ::Float64)::Any
 └ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:77
 ┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ speed(::Swan)::Float64

--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -29,12 +29,12 @@ end
 
 
 """
-    @assign <T> with <Trait1, Trait2, ...>
+    @assign <T> with <CanTrait1, CanTrait2, ...>
 
 Assign traits to the data type `T`.  For example:
 
 ```julia
-@assign Duck with Fly,Swim
+@assign Duck with CanFly,CanSwim
 ```
 
 is translated to something like:
@@ -48,7 +48,7 @@ where `x` is the name of the trait `X` in all lowercase, and `T` is the type
 being assigned with the trait `X`.
 """
 macro assign(T::Union{Expr,Symbol}, with::Symbol, traits::Union{Expr,Symbol})
-    usage = "Invalid @assign usage.  Try something like: @assign Duck with Fly,Swim"
+    usage = "Invalid usage: try something like: @assign Duck with CanFly,CanSwim"
     with === :with || throw(SyntaxError(usage))
     mod = __module__
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,7 +21,7 @@ function register(m::Module,
 end
 
 """
-    contracts(module, can_type::DataType)
+    contracts(module::Module, can_type::DataType)
 
 Returns a set of [`Contracts`](@ref) that are required to be implemented
 for objects that exihibits the specific `can_type` trait.
@@ -40,7 +40,7 @@ end
 
 """
     @check(T::Assignable)
-    check(module, T::Assignable)
+    check(module::Module, T::Assignable)
 
 Check if the data type `T` has fully implemented all trait functions that it was
 previously assigned. See also: [`@assign`](@ref).
@@ -72,21 +72,21 @@ function check(m::Module, T::Assignable)
 end
 
 """
-    required_contracts(module, T::Assignable)
+    required_contracts(module::Module, T::Assignable)
 
 Return a set of contracts that is required to be implemented for
 the provided type `T`.
 """
 function required_contracts(m::Module, T::Assignable)
     c = [contracts(m, t) for t in traits(m, T)]  # returns array of set of contracts
-    return isempty(c) ? valtype(storage().interface_map)() : union(c...) 
+    return isempty(c) ? valtype(storage().interface_map)() : union(c...)
 end
 
 """
     @implement <CanType> by <FunctionSignature>
 
 Register function signature for the specified `CanType` of a trait.
-You can use the [`check`](@ref) function to verify your implementation
+You can use the [`@check`](@ref) function to verify your implementation
 after these interface contracts are registered.  The function
 signature only needs to specify required arguments other than
 the object itself.  Also, return type is optional and in that case

--- a/src/types.jl
+++ b/src/types.jl
@@ -114,10 +114,12 @@ const CompositeTraitMap = MyDict{DataType,Set{DataType}}
 """
     TraitsStorage
 
-Type keeping all traits-related dynamic data.
-[`TraitsMap`](@ref)
-[`InterfaceMap`](@ref)
-[`CompositeTraitMap`](@ref)
+Keeps all traits-related dynamic data.
+
+# Fields
+- `traits_map`: see [`TraitsMap`](@ref)
+- `interface_map`: see [`InterfaceMap`](@ref)
+- `composite_map`: see [`CompositeTraitMap`](@ref)
 """
 struct TraitsStorage
     traits_map::TraitsMap

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,7 +76,7 @@ const TRAITS_STORAGE = TraitsStorage() # the singleton global storage
 storage() = TRAITS_STORAGE
 
 """
-    make_local_storage(module)
+    make_local_storage(module::Module)
 
 Create a temporary variable with a `TraitsStorage` object in given module.
 """
@@ -89,10 +89,11 @@ function get_local_storage(mod::Module)
 end
 
 """
-    getvalues(module, :table, key)
+    getvalues(module::Module, sym::Symbol, key)
 
-Get the set of values associated with the `key` in field `table`.
-Try first local (module-) table, if key not found use global table
+Get the set of values associated with the `key` in the dictionary
+from the storage as identified by `sym` (e.g. `:interface_map`).
+Try first local (module-) table, if key not found use global table.
 """
 function getvalues(mod::Module, sym::Symbol, key)
     st = get_local_storage(mod)
@@ -114,9 +115,10 @@ function get_traits_map(mod::Module)
 end
 
 """
-    pushdict!(module, :table, key, value)
+    pushdict!(module::Module, sym::Symbol, key, value)
 
-Insert value into set associated with `key` in the local (module-) `table`.
+Insert value into set associated with `key` in the dictionary as identified
+by `sym` (e.g. `:interface_map`) from the local storage.
 Create set if not pre-existent.
 """
 function pushdict!(mod::Module, sym::Symbol, key, val)
@@ -136,10 +138,10 @@ push_or_union!(s::Set, val::Set) = union!(s, val)
 import Base.rehash!
 
 """
-    move_to_global!(module)
+    move_to_global!(module::Module)
 
 Move all sets collected in local storage to global storage.
-Afterwared the local storage is emty.
+Afterwareds, the local storage is empty.
 """
 function move_to_global!(mod::Module)
     st = get_local_storage(mod)
@@ -159,12 +161,17 @@ function move_to_global!(mod::Module)
 end
 
 """
-    inittraits(module)
+    inittraits(module::Module)
 
 This function should be called like `inittraits(@__MODULE__)` inside the
 `__init__()' method of each module using `BinaryTraits`.
+
 Alternatively it can be called outside the module this way:
-`using Module; inittraits(Module)`, if `Module` missed to call it within its `::init__`.
+`using Module; inittraits(Module)`, if `Module` missed to call it
+within its `__init__` function.
+
+This is required only if the traits/interfaces are expected to be shared
+across modules.
 """
 function inittraits(mod::Module)
     move_to_global!(mod)


### PR DESCRIPTION
Updates after PR #43 
- All references to `check` function have been replaced with `@check` macro
- Include a new section about `inittrait` requirement for framework providers
- Minor doc string updates