### PR TITLE
Accept underscore in @implement function signature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryTraits"
 uuid = "190e46ec-f771-4705-b939-984896f7be0e"
 authors = ["Tom Kwong <tk3369@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -1,4 +1,6 @@
-The underlying machinery is extremely simple. When you define a traits like `@trait Fly as Ability`, it literally expands to the following code:
+## Basic machinery
+
+The machinery is extremely simple. When you define a traits like `@trait Fly as Ability`, it literally expands to the following code:
 
 ```julia
 abstract type FlyTrait <: Ability end
@@ -7,7 +9,7 @@ struct CannotFly <: FlyTrait end
 flytrait(x) = CannotFly()
 ```
 
-As you can see, our *opinion* is to define a new abstract type called  `FlyTrait`.  Likewise, we define `CanFly` and `CannotFly` subtypes.  Finally, we define a default trait function `flytrait` that just returns an instance of `CannotFly`.  Hence, all data types are automatically defined from the trait by default.
+As you can see, a new abstract type called  `FlyTrait` is automatically generated Likewise, we define `CanFly` and `CannotFly` subtypes.  Finally, we define a default trait function `flytrait` that just returns an instance of `CannotFly`.  Hence, all data types are automatically defined from the trait by default.
 
 Now, when you do `@assign Duck with CanFly,CanSwim`, it is just translated to:
 
@@ -15,6 +17,8 @@ Now, when you do `@assign Duck with CanFly,CanSwim`, it is just translated to:
 flytrait(::Duck) = CanFly()
 swimtrait(::Duck) = CanSwim()
 ```
+
+## Composite traits
 
 Making composite traits is slightly more interesting.  It creates a new trait by combining multiple traits together.  Having a composite trait is defined as one that exhibits *all* of the underlying traits.  Hence, `@trait FlySwim as Ability with CanFly,CanSwim` would be translated to the following:
 
@@ -30,4 +34,33 @@ function flyswimtrait(x)
         CannotFlySwim()
     end
 end
+```
+
+## Turning on verbose mode
+
+If you feel this package is a little too magical, don't worry.  To make things
+more transparent, you can turn on verbose mode.  All macro expansions are then
+displayed automatically.
+
+```julia
+julia> BinaryTraits.set_verbose(true)
+true
+
+julia> @trait Iterable prefix Is,Not
+┌ Info: Generated code
+│   code =
+│    quote
+│        abstract type IterableTrait <: Any end
+│        struct IsIterable <: IterableTrait
+│        end
+│        struct NotIterable <: IterableTrait
+│        end
+│        iterabletrait(x::Any) = begin
+│                NotIterable()
+│            end
+│        BinaryTraits.istrait(::Type{IterableTrait}) = begin
+│                true
+│            end
+│        nothing
+└    end
 ```

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -118,20 +118,18 @@ etc.  The `<FunctionSignature>` is basically a standard function signature.
 The followings are all valid usages:
 
 ```julia
-@implement CanFly by liftoff()
-@implement CanFly by fly(direction::Float64, altitude::Float64)
-@implement CanFly by speed()::Float64
+@implement CanFly by liftoff(_)
+@implement CanFly by fly(_, direction::Float64, altitude::Float64)
+@implement CanFly by speed(_)::Float64
 ```
 
-!!! note
-    When return type is not specified, it is default to `Any`.
-    Return type is currently not validated so it could be used here
-    just for documentation purpose.
+The underscore `_` is a special syntax where you can indicate which positional
+argument you want to pass an object to the function.  The object is expected
+to have a type that is assigned to the Fly trait.
 
-!!! note
-    As you will see below, the functions need to be defined with the
-    an object to be the first argument.  It is excluded from the interface
-    definition for convenience reasons.
+When return type is not specified, it is default to `Any`.
+Return type is currently not validated so it could be used here
+just for documentation purpose.
 
 ### Implementing interface contracts
 
@@ -139,21 +137,23 @@ A data type that is assigned to a trait should implement all interface contracts
 From the previous section, we established three contracts for the `Fly` trait -
 `liftoff`, `fly`, and `speed`. To satisfy those contracts, we must implement those functions.
 
-So let's say we are defining a `Bird` type that exhibits `Fly` trait, we implement
-the `liftoff` contract as shown below:
+For example, let's say we are defining a `Bird` type that exhibits `Fly` trait,
+we can implement the following contracts:
 
 ```julia
 abstract type Animal end
 struct Bird <: Animal end
 @assign Bird with CanFly
+
+# implmementation of CanFly contracts
 liftoff(bird::Bird) = "Hoo hoo!"
+fly(bird::Bird, direction::Float64, altitude::Float64) = "Getting there!"
+speed(bird::Bird) = 10.0
 ```
 
-Note that I must include an object to be the first argument of the function.
-In this case, I have chosen to pass a `Bird` object.
-
-However, it would be more practical when you have multiple types that satisfy
-the same trait.  So, Holy Trait comes to rescue:
+Here, we implement the contracts directly with the specific concrete type.
+What if you have multiple types that satisfy the same trait.
+Holy Trait comes to rescue:
 
 ```julia
 liftoff(x::Animal) = liftoff(flytrait(x), x)
@@ -180,7 +180,7 @@ julia> @check(Bird)
 
 The `@check` macro returns an `InterfaceReview` object, which gives you the
 validation result.  The warnings are generated so that it comes up in the log file.
-The following text is the display for the `InterfaceReview` object.  It is designed
+The string representation of the `InterfaceReview` object is designed
 to clearly show you what has been implemented and what's not.
 
 !!! note

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,18 +50,22 @@ What if we want to enforce an interface? e.g. animals that can fly must
 implement a `fly` method.  We can define that interface as follows:
 
 ```julia
-@implement CanFly by fly(direction::Float64, altitude::Float64)
+@implement CanFly by fly(_, direction::Float64, altitude::Float64)
 ```
+
+The underscore character is used to indicate how an object should be passed
+to the `fly` function.
 
 Then, to make sure that our implementation is correct, we can use the `@check`
 macro as shown below:
 
 ```julia
 julia> @check(Duck)
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Duck, ::Float64, ::Float64)::Nothing
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:170
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
 ❌ Duck is missing these implementations:
-1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
+1. FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
 ```
 
 Now, let's implement the method and check again:
@@ -71,7 +75,7 @@ julia> fly(duck::Duck, direction::Float64, altitude::Float64) = "Having fun!"
 
 julia> @check(Duck)
 ✅ Duck has implemented:
-1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
+1. FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
 ```
 
 ## Applying Holy Traits

--- a/examples/abstract_array.jl
+++ b/examples/abstract_array.jl
@@ -8,20 +8,20 @@ import Base: size, getindex, setindex!
 # -----------------------------------------------------------------------------
 
 @trait Dimension prefix Has,No
-@implement HasDimension by size()::Tuple
+@implement HasDimension by size(_)::Tuple
 
 # Bottom is used due to duck typing of the value `v` below
 const Bottom = Base.Bottom
 
 @trait LinearIndexing prefix Has,No
-@implement HasLinearIndexing by getindex(i::Int)
-@implement HasLinearIndexing by setindex!(v::Bottom, i::Int)
+@implement HasLinearIndexing by getindex(_, i::Int)
+@implement HasLinearIndexing by setindex!(_, v::Bottom, i::Int)
 
 const IntVarArg = Vararg{Int, N} where N
 
 @trait CartesianIndexing prefix Has,No
-@implement HasCartesianIndexing by getindex(I::IntVarArg)
-@implement HasCartesianIndexing by setindex!(v::Bottom, I::IntVarArg)
+@implement HasCartesianIndexing by getindex(_, I::IntVarArg)
+@implement HasCartesianIndexing by setindex!(_, v::Bottom, I::IntVarArg)
 
 # -----------------------------------------------------------------------------
 # Example: 1-D Int array
@@ -33,7 +33,7 @@ const Array1DInt = Array{Int,1}
 #=
 julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
-1. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+1. DimensionTrait: HasDimension ⇢ size(🔹)::Tuple
 =#
 
 @assign Array1DInt with HasLinearIndexing
@@ -41,9 +41,9 @@ julia> @check(Array1DInt)
 #=
 julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
-1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
-3. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+1. DimensionTrait: HasDimension ⇢ size(🔹)::Tuple
+2. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(🔹, ::Int64)::Any
+3. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(🔹, ::Union{}, ::Int64)::Any
 =#
 
 # 1D array is a specialized version of CartesianIndexing.
@@ -53,11 +53,11 @@ julia> @check(Array1DInt)
 #=
 julia> @check(Array1DInt)
 ✅ Array{Int64,1} has implemented:
-1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
-3. CartesianIndexingTrait: HasCartesianIndexing ⇢ getindex(::<Type>, ::Vararg{Int64,N} where N)::Any
-4. CartesianIndexingTrait: HasCartesianIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Vararg{Int64,N} where N)::Any
-5. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+1. CartesianIndexingTrait: HasCartesianIndexing ⇢ getindex(🔹, ::Vararg{Int64,N} where N)::Any
+2. CartesianIndexingTrait: HasCartesianIndexing ⇢ setindex!(🔹, ::Union{}, ::Vararg{Int64,N} where N)::Any
+3. DimensionTrait: HasDimension ⇢ size(🔹)::Tuple
+4. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(🔹, ::Int64)::Any
+5. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(🔹, ::Union{}, ::Int64)::Any
 =#
 
 # -----------------------------------------------------------------------------
@@ -76,7 +76,7 @@ Base.getindex(S::SquaresVector, i::Int) = i*i
 #=
 julia> @check(SquaresVector)
 ✅ SquaresVector has implemented:
-1. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(::<Type>, ::Int64)::Any
-2. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(::<Type>, ::Union{}, ::Int64)::Any
-3. DimensionTrait: HasDimension ⇢ size(::<Type>)::Tuple
+1. DimensionTrait: HasDimension ⇢ size(🔹)::Tuple
+2. LinearIndexingTrait: HasLinearIndexing ⇢ getindex(🔹, ::Int64)::Any
+3. LinearIndexingTrait: HasLinearIndexing ⇢ setindex!(🔹, ::Union{}, ::Int64)::Any
 =#

--- a/examples/iteration_indexing.jl
+++ b/examples/iteration_indexing.jl
@@ -7,8 +7,8 @@ using Revise, BinaryTraits
 # -----------------------------------------------------------------------------
 import Base: iterate
 @trait Iterable prefix Is,Not
-@implement IsIterable by iterate()::Any
-@implement IsIterable by iterate(state::Any)::Any
+@implement IsIterable by iterate(_)::Any
+@implement IsIterable by iterate(_, state::Any)::Any
 
 # Example from https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration-1
 struct Squares
@@ -23,8 +23,8 @@ Base.iterate(S::Squares, state=1) = state > S.count ? nothing : (state*state, st
 #=
 julia> @check(Squares)
 ✅ Squares has implemented:
-1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
-2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
+1. IterableTrait: IsIterable ⇢ iterate(🔹, ::Any)::Any
+2. IterableTrait: IsIterable ⇢ iterate(🔹)::Any
 =#
 
 # -----------------------------------------------------------------------------
@@ -33,13 +33,13 @@ julia> @check(Squares)
 import Base: getindex, setindex!, firstindex, lastindex
 
 @trait Indexable prefix Is,Not
-@implement IsIndexable by getindex(i::Any)
+@implement IsIndexable by getindex(_, i::Any)
 
 @trait IndexableFromBeginning prefix Is,Not
-@implement IsIndexableFromBeginning by firstindex()
+@implement IsIndexableFromBeginning by firstindex(_)
 
 @trait IndexableAtTheEnd prefix Is,Not
-@implement IsIndexableAtTheEnd by lastindex()
+@implement IsIndexableAtTheEnd by lastindex(_)
 
 # Make sure that `i` is untyped (i.e. `Any`) to adhere to the contract
 function Base.getindex(S::Squares, i)
@@ -50,10 +50,11 @@ end
 @assign Squares with IsIndexable
 @check(Squares)
 #=
+julia> @check(Squares)
 ✅ Squares has implemented:
-1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
-2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-3. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
+1. IndexableTrait: IsIndexable ⇢ getindex(🔹, ::Any)::Any
+2. IterableTrait: IsIterable ⇢ iterate(🔹, ::Any)::Any
+3. IterableTrait: IsIterable ⇢ iterate(🔹)::Any
 =#
 
 # We want to have the traits for indexing from beginning and at the end
@@ -61,17 +62,19 @@ end
 @check(Squares)
 #=
 julia> @check(Squares)
-┌ Warning: Missing implementation: IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::Squares)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
-┌ Warning: Missing implementation: IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::Squares)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+┌ Warning: Missing implementation
+│   contract = IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(🔹)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
+┌ Warning: Missing implementation
+│   contract = IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(🔹)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
 ✅ Squares has implemented:
-1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
-2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-3. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
+1. IndexableTrait: IsIndexable ⇢ getindex(🔹, ::Any)::Any
+2. IterableTrait: IsIterable ⇢ iterate(🔹, ::Any)::Any
+3. IterableTrait: IsIterable ⇢ iterate(🔹)::Any
 ❌ Squares is missing these implementations:
-1. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::<Type>)::Any
-2. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
+1. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(🔹)::Any
+2. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(🔹)::Any
 =#
 
 # Let's implement them now.
@@ -81,9 +84,9 @@ Base.lastindex(S::Squares) = length(S)
 #=
 julia> @check(Squares)
 ✅ Squares has implemented:
-1. IterableTrait: IsIterable ⇢ iterate(::<Type>)::Any
-2. IterableTrait: IsIterable ⇢ iterate(::<Type>, ::Any)::Any
-3. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(::<Type>)::Any
-4. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(::<Type>)::Any
-5. IndexableTrait: IsIndexable ⇢ getindex(::<Type>, ::Any)::Any
+1. IndexableAtTheEndTrait: IsIndexableAtTheEnd ⇢ lastindex(🔹)::Any
+2. IndexableFromBeginningTrait: IsIndexableFromBeginning ⇢ firstindex(🔹)::Any
+3. IndexableTrait: IsIndexable ⇢ getindex(🔹, ::Any)::Any
+4. IterableTrait: IsIterable ⇢ iterate(🔹, ::Any)::Any
+5. IterableTrait: IsIterable ⇢ iterate(🔹)::Any
 =#

--- a/examples/user_guide_example.jl
+++ b/examples/user_guide_example.jl
@@ -8,9 +8,9 @@ abstract type Ability end
 @trait Swim as Ability
 
 # Define interface contracts for the type.
-@implement CanFly by liftoff()
-@implement CanFly by fly(direction::Float64, altitude::Float64)
-@implement CanFly by speed()::Float64
+@implement CanFly by liftoff(_)
+@implement CanFly by fly(_, direction::Float64, altitude::Float64)
+@implement CanFly by speed(_)::Float64
 
 # Define a data type and assign it traits.
 struct Crane end
@@ -20,16 +20,19 @@ struct Crane end
 @check(Crane)
 #=
 julia> @check(Crane)
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ speed(::Crane)::Float64
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ liftoff(::Crane)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Crane, ::Float64, ::Float64)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:200
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ speed(🔹)::Float64
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ liftoff(🔹)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
 ❌ Crane is missing these implementations:
-1. FlyTrait: CanFly ⇢ speed(::<Type>)::Float64
-2. FlyTrait: CanFly ⇢ liftoff(::<Type>)::Any
-3. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
+1. FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
+2. FlyTrait: CanFly ⇢ speed(🔹)::Float64
+3. FlyTrait: CanFly ⇢ liftoff(🔹)::Any
 =#
 
 # What about composite traits?
@@ -43,14 +46,17 @@ struct Swan end
 @check(Swan)
 #=
 julia> @check(Swan)
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ fly(::Swan, ::Float64, ::Float64)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:77
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ speed(::Swan)::Float64
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:77
-┌ Warning: Missing implementation: FlyTrait: CanFly ⇢ liftoff(::Swan)::Any
-└ @ BinaryTraits ~/.julia/dev/BinaryTraits/src/interface.jl:77
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ speed(🔹)::Float64
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
+┌ Warning: Missing implementation
+│   contract = FlyTrait: CanFly ⇢ liftoff(🔹)::Any
+└ @ BinaryTraits ~/.julia/dev/BinaryTraits.jl/src/interface.jl:59
 ❌ Swan is missing these implementations:
-1. FlyTrait: CanFly ⇢ fly(::<Type>, ::Float64, ::Float64)::Any
-2. FlyTrait: CanFly ⇢ speed(::<Type>)::Float64
-3. FlyTrait: CanFly ⇢ liftoff(::<Type>)::Any
+1. FlyTrait: CanFly ⇢ fly(🔹, ::Float64, ::Float64)::Any
+2. FlyTrait: CanFly ⇢ speed(🔹)::Float64
+3. FlyTrait: CanFly ⇢ liftoff(🔹)::Any
 =#

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -167,6 +167,11 @@ function parse_implement(can_type, by, sig)
         push!(func_arg_types, extract_type(x, can_type, :(Base.Bottom)))
     end
 
+    # Check that at least one of the arguments is the can-type
+    if findfirst(x -> x === can_type, func_arg_types) === nothing
+        throw(SyntaxError("The function signature must have at least 1 underscore."))
+    end
+
     return (func_name, func_arg_names, func_arg_types, func_kwarg_names, return_type)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,8 +28,9 @@ struct Contract{T <: DataType, F <: Function}
 end
 
 function Base.show(io::IO, c::Contract)
-    typ = Symbol(TYPE_PLACEHOLDER)
-    args = string("(", join([typ, c.args...], ", ::"))
+    # prefix the can-type with a different symbol because it's not subtype relation
+    args = [x == c.can_type ? "🚀$x" : "::$x" for x in c.args]
+    args = string("(", join(args, ", "))
     if length(c.kwargs) > 0
         args = string(args, "; ", join(c.kwargs, ", "))
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,7 +29,7 @@ end
 
 function Base.show(io::IO, c::Contract)
     # prefix the can-type with a different symbol because it's not subtype relation
-    args = [x == c.can_type ? "🚀$x" : "::$x" for x in c.args]
+    args = [x == c.can_type ? "🔹" : "::$x" for x in c.args]
     args = string("(", join(args, ", "))
     if length(c.kwargs) > 0
         args = string(args, "; ", join(c.kwargs, ", "))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,8 +125,9 @@ module SyntaxErrors
             @test @testme @trait Fly with Eat,Drink,1  # 1 is not a symbol
 
             @test @testme @assign Dog with 1           # 1 is not a symbol
-            # invalid argument
+
             @test @testme @implement CanCreep by creep2(_, []) # invalid argument
+            @test @testme @implement CanCreep by creep3()      # no underscore
         end
     end
 end
@@ -229,6 +230,15 @@ module Interfaces
     @assign Snake with CanCreep
     creep1(::Snake, ::Integer) = 1
 
+    @trait PlayNice
+    @implement CanPlayNice by play(_,_)
+    struct Dog end
+    struct Cat end
+    play(::Dog, ::Dog) = 1
+    play(::Cat, ::Dog) = 2
+    @assign Dog with CanPlayNice
+    @assign Cat with CanPlayNice
+
     function test()
         @testset "Interface validation" begin
 
@@ -302,6 +312,12 @@ module Interfaces
             check_snake = @check(Snake)
             @test check_snake.result
             @test check_snake.implemented |> length == 1
+
+            # Multiple underscores in the contract
+            check_dog = @check(Dog)
+            check_cat = @check(Cat)
+            @test check_dog.result === true    # Dog plays nice with Dog
+            @test check_cat.result === false   # Cat does not play nice with Cat
 
             # code coverage
             @test_throws SyntaxError extract_type(:([]), :(CanFly), nothing)


### PR DESCRIPTION
This PR changes the `@implement` macro such that the function signature must include an underscore that represents the argument position of a data type being passed.  The underscore does not need to be at the first position. Fixes #29.  

**Tasks** 
- [x] code changes to support a single can-type that appears in any position
- [x] error handling... what if the underscore does not exist or the argument list is empty?
- [x] documentations update