### PR TITLE
Remove custom hasmethod implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.2' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 [compat]
 MacroTools = "0.5"
 ExprTools = "0.1"
-julia = "1"
+julia = "1.2"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 [compat]
 MacroTools = "0.5"
 ExprTools = "0.1"
-julia = "1.2"
+julia = "1.6"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Resolves #54.

The custom logic was originally developed to address a Bottom type issue with julialang (https://github.com/JuliaLang/julia/issues/30808). However, the custom logic does not work properly for UnionAll signatures as seen from #54.

It appears that the original Julia hasmethod issue has been resolved. See my latest comment in that issue. So, I'm removing the custom logic here. All tests pass for Julia version 1.6 and above.

I think it's time to move on. I will tag a new release 0.7.0 after this is merged. People using old Julia version can continue using BinaryTraits 0.6.0 (albeit running into issues like #54).

Cc: @KlausC 