### PR TITLE
Hierarchical, Contradictory Traits

### DIFF
--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -7,10 +7,15 @@ the ones that were assigned to any supertypes of `T`.
 See also [`@assign`](@ref).
 """
 function traits(m::Module, T::Assignable)
-    traits_map = get_traits_map(m)
+    _traits_map = collect(pairs(get_traits_map(m)))
+    traits_map = sort(_traits_map; by = p -> _depth(first(p)))
     base = Set{DataType}()
-    for (Tmap, s) in pairs(traits_map)
+    for (Tmap, s) in traits_map
         if T <: Tmap
+            for trait in s
+                T_new = binary_trait_type(trait)
+                filter!(t -> !(binary_trait_type(t) <: T_new), base)
+            end
             union!(base, s)
         end
     end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -107,15 +107,6 @@ function make_tuple_type(T::Assignable, c::Contract)
     return Tuple{args...}
 end
 
-function make_traited_tuple_type(T::Assignable, c::Contract)
-    args = mapreduce((a, b) -> vcat(a..., b), c.args) do t
-        return t == c.trait ? (t,T) : t
-    end
-    args = reduce(vcat, args)
-
-    return Tuple{args...}
-end
-
 """
     required_contracts(module::Module, T::Assignable)
 

--- a/src/trait.jl
+++ b/src/trait.jl
@@ -5,6 +5,8 @@ export trait
 
 abstract type BinaryTrait{T} end
 
+binary_trait_type(::Type{<:BinaryTrait{T}}) where T = T
+
 # This sub-module is used to keep standard prefix types
 module Prefix
     import ..BinaryTraits

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,6 +48,16 @@ function define_const!(mod::Module, name::Symbol, val)
         mod.eval(name)
     end
 end
+
+# Utility to test the depth in the type tree of a given type. Root of the tree has depth 0
+function _depth(::Type{T}) where {T}
+    if T === Any 
+        return 0
+    else
+        return 1 + _depth(supertype(T))
+    end
+end
+
 # -----------------------------------------------------------------------------------------
 # Storage management
 # -----------------------------------------------------------------------------------------
@@ -169,4 +179,3 @@ function Base.isempty(st::TraitsStorage)
     isempty(st.interface_map) &&
     isempty(st.composite_map)
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Test
     include("test_parametric_type.jl")
     include("test_cross_module.jl")
     include("test_interfaces.jl")
+    include("test_hierarchy_interfaces.jl")
     include("test_traitfn.jl")
     VERSION >= v"1.1" && include("test_return_types.jl")
 end

--- a/test/test_hierarchy_interfaces.jl
+++ b/test/test_hierarchy_interfaces.jl
@@ -1,0 +1,38 @@
+module HierarchicalInterfaces
+
+using BinaryTraits
+using Test
+
+abstract type Bird end
+struct Penguin <: Bird end
+struct Ostrich <: Bird end
+
+@trait Fly
+@implement Negative{Fly} by fly(_)
+@assign Bird with Positive{Fly}
+@assign Penguin with Negative{Fly}
+@assign Ostrich with Negative{Fly}
+
+@traitfn fly(::Positive{Fly}) = "Flap!"
+
+fly(::Ostrich) = "I'm a flightless bird!"
+
+# Penguin should not satisfy the interface
+function test_negative()
+    check_result = @check(Penguin)
+    @test check_result.result == false
+end
+
+# Ostrich does satisfy the interface
+function test_positive()
+    check_result = @check(Ostrich)
+    @test check_result.result == true
+end
+
+end
+
+using .HierarchicalInterfaces
+HI = HierarchicalInterfaces
+
+HI.test_negative()
+HI.test_positive()


### PR DESCRIPTION
Addresses !60 and introduces a test which fails on `master` but passes on this branch.

The fundamental issue this PR addresses is the following: 

We can apply `Positive{Trait}` to an abstract type, then apply `Negative{Trait}` to a subtype. We then implement a default `@traitfn` for `Positive{Trait}` but require a manual method implementation for the `Negative{Trait}`. If we run `@check` on the subtype, it can incorrectly show that the interface is satisfied.

To solve this problem, there are two things that we need to do. 

1. Retrieve the proper `Positive/Negative` version of the trait. 
 
To do this, we first call `traits(::Module, T::Assignable)` and traverse the type tree to find all traits which are applied to the `T` in question. We now sort the tree beforehand, proceeding down the tree from `Any` rather than in an unordered fashion. This allows us to determine whether the last instance of a trait applied to a type was `Positive` or `Negative`

2. Verify in the interface checker that the method which matches the type signature for the interface **also** matches the trait types we expect. 

If we define `foo(::Any) = foo(::Negative{Trait}, ::Any)`, then we require `foo(::MyType)` for the `Positive{Trait}` interface, the checker can give a false positive that the interface is satisfied because `foo(::Any)` will pass `hasmethod(foo, Tuple{MyType})`. We need to introduce a second check when `hasmethod` passes which verifies that the types in the locations where the trait is substituted for the type in question that the resulting type in the method signature also possesses the trait. I call this extra check `method_traits_match`

This PR assumes that any given type cannot satisfy both `Positive{Trait}` and `Negative{Trait}` for any fixed `Trait`. This is technically permissible according to `BinaryTraits.jl` (assigning both to a type doesn't throw an error), so perhaps this PR is a wash from the start. However, I think this is a very useful capability. For example, it allows us to define a default interface for a type hierarchy via `Negative{Trait}`, and then we can special-case subsets of the type tree which satisfy a separate interface for `Positive{Trait}`. 